### PR TITLE
Fix Issue #19: Menu内绑定鼠标单击处理函数 调用fileDlg.BrowseForFile 或GetOpenFileName 连续两次或三次就会触发异常。

### DIFF
--- a/duilib/Box/ListBox.cpp
+++ b/duilib/Box/ListBox.cpp
@@ -1142,6 +1142,9 @@ bool ListBox::CanPaintSelectedColors(bool bHasStateImages) const
 bool ListBox::ButtonDown(const EventArgs& msg)
 {
     bool ret = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     StopScroll();
     return ret;
 }

--- a/duilib/Box/VirtualListBox.cpp
+++ b/duilib/Box/VirtualListBox.cpp
@@ -626,8 +626,8 @@ void VirtualListBox::VSendEvent(const EventArgs& args, bool bFromItem)
 {
     if (bFromItem) {
         EventArgs msg = args;
-        msg.pSender = this;
-        size_t nItemIndex = GetItemIndex(args.pSender);
+        msg.SetSender(this);
+        size_t nItemIndex = GetItemIndex(args.GetSender());
         if (nItemIndex < GetItemCount()) {
             msg.wParam = nItemIndex;
             msg.lParam = GetDisplayItemElementIndex(nItemIndex);
@@ -641,7 +641,7 @@ void VirtualListBox::VSendEvent(const EventArgs& args, bool bFromItem)
     else if ((args.Type == kEventMouseDoubleClick) ||
              (args.Type == kEventClick) ||
              (args.Type == kEventRClick)) {
-        if (args.pSender == this) {
+        if (args.GetSender() == this) {
             ASSERT(args.wParam == 0);
             ASSERT(args.lParam == 0);
             EventArgs msg = args;

--- a/duilib/Control/CheckCombo.cpp
+++ b/duilib/Control/CheckCombo.cpp
@@ -470,10 +470,10 @@ void CheckCombo::SetDropBoxSize(UiSize szDropBox, bool bNeedScaleDpi)
 
 bool CheckCombo::OnSelectItem(const ui::EventArgs& args)
 {
-    if (args.pSender == nullptr) {
+    if (args.GetSender() == nullptr) {
         return true;
     }
-    CheckBox* pCheckBox = dynamic_cast<CheckBox*>(args.pSender);
+    CheckBox* pCheckBox = dynamic_cast<CheckBox*>(args.GetSender());
     if (pCheckBox == nullptr) {
         return true;
     }
@@ -492,10 +492,10 @@ bool CheckCombo::OnSelectItem(const ui::EventArgs& args)
 
 bool CheckCombo::OnUnSelectItem(const ui::EventArgs& args)
 {
-    if (args.pSender == nullptr) {
+    if (args.GetSender() == nullptr) {
         return true;
     }
-    CheckBox* pCheckBox = dynamic_cast<CheckBox*>(args.pSender);
+    CheckBox* pCheckBox = dynamic_cast<CheckBox*>(args.GetSender());
     if (pCheckBox == nullptr) {
         return true;
     }

--- a/duilib/Control/ColorControl.cpp
+++ b/duilib/Control/ColorControl.cpp
@@ -51,6 +51,9 @@ void ColorControl::PaintBkImage(IRender* pRender)
 bool ColorControl::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     UiRect rect = GetRect();
     if (rect.ContainsPt(msg.ptMouse)) {
         m_bMouseDown = true;
@@ -62,7 +65,10 @@ bool ColorControl::ButtonDown(const EventArgs& msg)
 
 bool ColorControl::MouseMove(const EventArgs& msg)
 {
-    bool bRet = __super::MouseMove(msg);        
+    bool bRet = __super::MouseMove(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (m_bMouseDown) {
         UiRect rect = GetRect();
         OnSelectPosChanged(rect, msg.ptMouse);

--- a/duilib/Control/ColorPicker.cpp
+++ b/duilib/Control/ColorPicker.cpp
@@ -410,6 +410,9 @@ private:
     virtual bool ButtonDown(const EventArgs& msg)
     {
         bool bRet = __super::ButtonDown(msg);
+        if (msg.IsSenderExpired()) {
+            return false;
+        }
 
         //更新选择颜色
         m_selColor = GetMousePosColor(msg.ptMouse);

--- a/duilib/Control/ColorPickerStatard.cpp
+++ b/duilib/Control/ColorPickerStatard.cpp
@@ -153,6 +153,9 @@ bool ColorPickerStatard::MouseMove(const EventArgs& msg)
 bool ColorPickerStatard::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (GetRect().ContainsPt(msg.ptMouse)) {
         UiColor color;
         if (GetColorInfo(msg.ptMouse, color)) {

--- a/duilib/Control/ColorPickerStatardGray.cpp
+++ b/duilib/Control/ColorPickerStatardGray.cpp
@@ -257,6 +257,9 @@ bool ColorPickerStatardGray::MouseMove(const EventArgs& msg)
 bool ColorPickerStatardGray::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (GetRect().ContainsPt(msg.ptMouse)) {
         UiColor color;
         if (GetColorInfo(msg.ptMouse, color)) {

--- a/duilib/Control/IPAddress.cpp
+++ b/duilib/Control/IPAddress.cpp
@@ -164,7 +164,7 @@ void IPAddress::SendEvent(EventType eventType,
 
 void IPAddress::SendEvent(const EventArgs& msg)
 {
-    if ((msg.pSender == this) && (msg.Type == kEventKillFocus)) {
+    if ((msg.GetSender() == this) && (msg.Type == kEventKillFocus)) {
         Control* pNewFocus = (Control*)msg.wParam;
         if (std::find(m_editList.begin(), m_editList.end(), pNewFocus) != m_editList.end()) {
             //焦点切换到编辑框，不发出KillFocus事件

--- a/duilib/Control/ListCtrl.cpp
+++ b/duilib/Control/ListCtrl.cpp
@@ -380,12 +380,12 @@ void ListCtrl::InitReportView()
                 EventArgs msg = args;
                 msg.wParam = (WPARAM)pItem;
                 msg.lParam = pItem->GetElementIndex();
-                msg.pSender = this;
+                msg.SetSender(this);
                 SendEvent(msg);
             }
             else if (args.Type == kEventSelChange) {
                 EventArgs msg = args;
-                msg.pSender = this;
+                msg.SetSender(this);
                 SendEvent(msg);
             }
         };
@@ -437,12 +437,12 @@ void ListCtrl::InitIconView()
                 EventArgs msg = args;
                 msg.wParam = (WPARAM)pItem;
                 msg.lParam = pItem->GetElementIndex();
-                msg.pSender = this;
+                msg.SetSender(this);
                 SendEvent(msg);
             }
             else if (args.Type == kEventSelChange) {
                 EventArgs msg = args;
-                msg.pSender = this;
+                msg.SetSender(this);
                 SendEvent(msg);
             }
         };
@@ -496,12 +496,12 @@ void ListCtrl::InitListView()
                 EventArgs msg = args;
                 msg.wParam = (WPARAM)pItem;
                 msg.lParam = pItem->GetElementIndex();
-                msg.pSender = this;
+                msg.SetSender(this);
                 SendEvent(msg);
             }
             else if (args.Type == kEventSelChange) {
                 EventArgs msg = args;
-                msg.pSender = this;
+                msg.SetSender(this);
                 SendEvent(msg);
             }
         };
@@ -2339,7 +2339,7 @@ void ListCtrl::OnViewMouseEvents(const EventArgs& msg)
         (msg.Type == kEventMouseRButtonUp) ||
         (msg.Type == kEventMouseRDoubleClick) ||
         (msg.Type == kEventMouseMenu)) {
-        if (msg.pSender != m_pRichEdit) {
+        if (msg.GetSender() != m_pRichEdit) {
             LeaveEditMode();
         }
     }    
@@ -2347,7 +2347,7 @@ void ListCtrl::OnViewMouseEvents(const EventArgs& msg)
 
 void ListCtrl::OnViewKeyboardEvents(const EventArgs& msg)
 {
-    if (msg.pSender != m_pRichEdit) {
+    if (msg.GetSender() != m_pRichEdit) {
         LeaveEditMode();
     }    
 }

--- a/duilib/Control/ListCtrlHeader.cpp
+++ b/duilib/Control/ListCtrlHeader.cpp
@@ -191,14 +191,14 @@ ListCtrlHeaderItem* ListCtrlHeader::InsertColumn(int32_t columnIndex, const List
     //挂载右键点击事件，进行转接
     pHeaderItem->AttachRClick([this, pHeaderItem](const EventArgs& args) {
         EventArgs msg(args);
-        msg.pSender = this;
+        msg.SetSender(this);
         msg.wParam = (WPARAM)pHeaderItem;
         SendEvent(msg);
         return true;
         });
     pHeaderSplit->AttachRClick([this, pHeaderItem](const EventArgs& args) {
         EventArgs msg(args);
-        msg.pSender = this;
+        msg.SetSender(this);
         msg.wParam = (WPARAM)pHeaderItem;
         SendEvent(msg);
         return true;

--- a/duilib/Control/ListCtrlView.cpp
+++ b/duilib/Control/ListCtrlView.cpp
@@ -153,23 +153,23 @@ void ListCtrlView::AttachMouseEvents(Control* pListBoxItem)
     if (pListBoxItem != nullptr) {
         //挂载鼠标事件
         pListBoxItem->AttachButtonDown([this](const EventArgs& args) {
-            OnButtonDown(args.ptMouse, args.pSender);
+            OnButtonDown(args.ptMouse, args.GetSender());
             return true;
             });
         pListBoxItem->AttachButtonUp([this](const EventArgs& args) {
-            OnButtonUp(args.ptMouse, args.pSender);
+            OnButtonUp(args.ptMouse, args.GetSender());
             return true;
             });
         pListBoxItem->AttachRButtonDown([this](const EventArgs& args) {
-            OnRButtonDown(args.ptMouse, args.pSender);
+            OnRButtonDown(args.ptMouse, args.GetSender());
             return true;
             });
         pListBoxItem->AttachRButtonUp([this](const EventArgs& args) {
-            OnButtonUp(args.ptMouse, args.pSender);
+            OnButtonUp(args.ptMouse, args.GetSender());
             return true;
             });
         pListBoxItem->AttachMouseMove([this](const EventArgs& args) {
-            OnMouseMove(args.ptMouse, args.pSender);
+            OnMouseMove(args.ptMouse, args.GetSender());
             return true;
             });
         pListBoxItem->AttachWindowKillFocus([this](const EventArgs&) {
@@ -182,15 +182,21 @@ void ListCtrlView::AttachMouseEvents(Control* pListBoxItem)
 bool ListCtrlView::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
-    OnButtonDown(msg.ptMouse, msg.pSender);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
+    OnButtonDown(msg.ptMouse, msg.GetSender());
     return bRet;
 }
 
 bool ListCtrlView::ButtonUp(const EventArgs& msg)
 {
     bool bRet = __super::ButtonUp(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     //按住Ctrl或者Shift的时候，不触发清空选择操作，避免误操作
-    Control* pSender = msg.pSender;
+    Control* pSender = msg.GetSender();
     if (msg.wParam & MK_CONTROL) {
         pSender = nullptr;
     }
@@ -204,27 +210,39 @@ bool ListCtrlView::ButtonUp(const EventArgs& msg)
 bool ListCtrlView::RButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::RButtonDown(msg);
-    OnRButtonDown(msg.ptMouse, msg.pSender);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
+    OnRButtonDown(msg.ptMouse, msg.GetSender());
     return bRet;
 }
 
 bool ListCtrlView::RButtonUp(const EventArgs& msg)
 {
     bool bRet = __super::RButtonUp(msg);
-    OnRButtonUp(msg.ptMouse, msg.pSender);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
+    OnRButtonUp(msg.ptMouse, msg.GetSender());
     return bRet;
 }
 
 bool ListCtrlView::MouseMove(const EventArgs& msg)
 {
     bool bRet = __super::MouseMove(msg);
-    OnMouseMove(msg.ptMouse, msg.pSender);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
+    OnMouseMove(msg.ptMouse, msg.GetSender());
     return bRet;
 }
 
 bool ListCtrlView::OnWindowKillFocus(const EventArgs& msg)
 {
     bool bRet = __super::OnWindowKillFocus(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     OnWindowKillFocus();
     return bRet;
 }

--- a/duilib/Control/Menu.cpp
+++ b/duilib/Control/Menu.cpp
@@ -812,7 +812,7 @@ bool MenuItem::ButtonUp(const ui::EventArgs& msg)
     }
     std::weak_ptr<WeakFlag> weakFlag = pWindow->GetWeakFlag();
     bool ret = __super::ButtonUp(msg);
-    if (ret && !weakFlag.expired()) {
+    if (ret && !weakFlag.expired() && !msg.IsSenderExpired()) {
         //这里处理下如果有子菜单则显示子菜单
         if (!CheckSubMenuItem()){
             ContextMenuParam param;
@@ -833,7 +833,7 @@ bool MenuItem::MouseEnter(const ui::EventArgs& msg)
     }
     std::weak_ptr<WeakFlag> weakFlag = pWindow->GetWeakFlag();
     bool ret = __super::MouseEnter(msg);
-    if (!weakFlag.expired() && IsHotState()) {
+    if (!weakFlag.expired() && IsHotState() && !msg.IsSenderExpired()) {
         //这里处理下如果有子菜单则显示子菜单
         if (!CheckSubMenuItem()) {
             ContextMenuParam param;

--- a/duilib/Control/RichText.cpp
+++ b/duilib/Control/RichText.cpp
@@ -728,6 +728,9 @@ DString RichText::ToString(const RichTextSlice& textSlice, const DString& indent
 bool RichText::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     for (size_t index = 0; index < m_textData.size(); ++index) {
         RichTextDataEx& textData = m_textData[index];
         textData.m_bMouseDown = false;
@@ -748,6 +751,9 @@ bool RichText::ButtonDown(const EventArgs& msg)
 bool RichText::ButtonUp(const EventArgs& msg)
 {
     bool bRet = __super::ButtonUp(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     for (size_t index = 0; index < m_textData.size(); ++index) {
         RichTextDataEx& textData = m_textData[index];
         if (textData.m_linkUrl.empty()) {

--- a/duilib/Control/Split.h
+++ b/duilib/Control/Split.h
@@ -208,6 +208,9 @@ template<typename InheritType>
 bool SplitTemplate<InheritType>::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     Box* pParent = this->GetParent();
     if (!this->IsEnabled() || (pParent == nullptr)) {
         return bRet;
@@ -302,6 +305,9 @@ template<typename InheritType>
 bool SplitTemplate<InheritType>::ButtonUp(const EventArgs& msg)
 {
     bool bRet = __super::ButtonUp(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     StopSplitDrag();
     return bRet;
 }

--- a/duilib/Control/TabCtrl.cpp
+++ b/duilib/Control/TabCtrl.cpp
@@ -48,7 +48,7 @@ void TabCtrl::OnInit()
 
 void TabCtrl::HandleEvent(const EventArgs& msg)
 {
-    if ((msg.pSender == this) && (msg.Type == kEventSelect)) {
+    if ((msg.GetSender() == this) && (msg.Type == kEventSelect)) {
         //尝试设置关联的TabBox
         if ((m_pTabBox == nullptr) && !m_tabBoxName.empty()) {
             SetTabBoxName(m_tabBoxName.c_str());
@@ -68,7 +68,7 @@ void TabCtrl::HandleEvent(const EventArgs& msg)
             }
         }
     }
-    if ((msg.pSender == this) && ((msg.Type == kEventSelect) || (msg.Type == kEventUnSelect))) {
+    if ((msg.GetSender() == this) && ((msg.Type == kEventSelect) || (msg.Type == kEventUnSelect))) {
         TabCtrlItem* pItem = nullptr;
         size_t nSelectIndex = msg.wParam;
         Control* pControl = GetItemAt(nSelectIndex);
@@ -281,7 +281,7 @@ void TabCtrlItem::OnInit()
 
 void TabCtrlItem::HandleEvent(const EventArgs& msg)
 {
-    if ((msg.pSender == this) && (msg.Type == kEventStateChange) && (m_pLine != nullptr)) {
+    if ((msg.GetSender() == this) && (msg.Type == kEventStateChange) && (m_pLine != nullptr)) {
         //处理分割线的状态
         AdjustItemLineStatus();
     }
@@ -659,6 +659,9 @@ void TabCtrlItem::OnPrivateSetSelected()
 bool TabCtrlItem::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (!IsSelected() && IsActivatable()) {
         //按鼠标左键的时候，选择
         Selected(true, true);

--- a/duilib/Control/TreeView.cpp
+++ b/duilib/Control/TreeView.cpp
@@ -240,6 +240,9 @@ void TreeNode::PaintStateImages(IRender* pRender)
 bool TreeNode::ButtonDown(const EventArgs& msg)
 {
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (!IsEnabled()) {
         return bRet;
     }
@@ -308,7 +311,7 @@ TreeView* TreeNode::GetTreeView() const
 
 bool TreeNode::OnDoubleClickItem(const EventArgs& args)
 {
-    TreeNode* pItem = dynamic_cast<TreeNode*>(args.pSender);
+    TreeNode* pItem = dynamic_cast<TreeNode*>(args.GetSender());
     ASSERT(pItem != nullptr);
     if (pItem != nullptr) {
         pItem->SetExpand(!pItem->IsExpand(), true);
@@ -318,7 +321,7 @@ bool TreeNode::OnDoubleClickItem(const EventArgs& args)
 
 bool TreeNode::OnNodeCheckStatusChanged(const EventArgs& args)
 {
-    TreeNode* pItem = dynamic_cast<TreeNode*>(args.pSender);
+    TreeNode* pItem = dynamic_cast<TreeNode*>(args.GetSender());
     ASSERT(pItem != nullptr);
     if ((pItem != nullptr) && (m_pTreeView != nullptr)) {
         m_pTreeView->OnNodeCheckStatusChanged(pItem);

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -1636,7 +1636,7 @@ void Control::SendEvent(EventType eventType,
                         const UiPoint& mousePos)
 {
     EventArgs msg;
-    msg.pSender = this;
+    msg.SetSender(this);
     msg.Type = eventType;
     msg.chKey = tChar;
     msg.wParam = wParam;
@@ -1848,8 +1848,11 @@ bool Control::HasHotState()
     return bState;
 }
 
-bool Control::MouseEnter(const EventArgs& /*msg*/)
+bool Control::MouseEnter(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if( IsEnabled() ) {
         if (GetState() == kControlStateNormal) {
             PrivateSetState(kControlStateHot);
@@ -1866,8 +1869,11 @@ bool Control::MouseEnter(const EventArgs& /*msg*/)
     return false;
 }
 
-bool Control::MouseLeave(const EventArgs& /*msg*/)
+bool Control::MouseLeave(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if( IsEnabled() ) {
         if (GetState() == kControlStateHot) {
             PrivateSetState(kControlStateNormal);
@@ -1885,8 +1891,11 @@ bool Control::MouseLeave(const EventArgs& /*msg*/)
     return false;
 }
 
-bool Control::ButtonDown(const EventArgs& /*msg*/)
+bool Control::ButtonDown(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if( IsEnabled() ) {
         PrivateSetState(kControlStatePushed);
         SetMouseFocused(true);
@@ -1897,6 +1906,9 @@ bool Control::ButtonDown(const EventArgs& /*msg*/)
 
 bool Control::ButtonUp(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if( IsMouseFocused() ) {
         SetMouseFocused(false);
         auto player = GetAnimationManager().GetAnimationPlayer(AnimationType::kAnimationHot);
@@ -1922,8 +1934,11 @@ bool Control::ButtonDoubleClick(const EventArgs& /*msg*/)
     return true;
 }
 
-bool Control::RButtonDown(const EventArgs& /*msg*/)
+bool Control::RButtonDown(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (IsEnabled()) {
         SetMouseFocused(true);
     }
@@ -1932,6 +1947,9 @@ bool Control::RButtonDown(const EventArgs& /*msg*/)
 
 bool Control::RButtonUp(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (IsMouseFocused()) {
         SetMouseFocused(false);
         if (IsPointInWithScrollOffset(msg.ptMouse)) {
@@ -2041,8 +2059,11 @@ bool Control::OnSetFocus(const EventArgs& /*msg*/)
     return true;
 }
 
-bool Control::OnKillFocus(const EventArgs& /*msg*/)
+bool Control::OnKillFocus(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (GetState() == kControlStateHot) {
         SetState(kControlStateNormal);
     }
@@ -3073,16 +3094,19 @@ void Control::DetachXmlBubbledEvent(EventType eventType)
 
 bool Control::FireAllEvents(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     std::weak_ptr<WeakFlag> weakflag = GetWeakFlag();
     bool bRet = true;//当值为false时，就不再调用回调函数和处理函数
 
-    if (msg.pSender == this) {
+    if (msg.GetSender() == this) {
         if (bRet && (m_pOnEvent != nullptr) && !m_pOnEvent->empty()) {
             auto callback = m_pOnEvent->find(msg.Type);
             if (callback != m_pOnEvent->end()) {
                 bRet = callback->second(msg);
             }
-            if (weakflag.expired()) {
+            if (weakflag.expired() || msg.IsSenderExpired()) {
                 return false;
             }
 
@@ -3090,7 +3114,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
             if (callback != m_pOnEvent->end()) {
                 bRet = callback->second(msg);
             }
-            if (weakflag.expired()) {
+            if (weakflag.expired() || msg.IsSenderExpired()) {
                 return false;
             }
         }
@@ -3100,7 +3124,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
             if (callback != m_pOnXmlEvent->end()) {
                 bRet = callback->second(msg);
             }
-            if (weakflag.expired()) {
+            if (weakflag.expired() || msg.IsSenderExpired()) {
                 return false;
             }
 
@@ -3108,7 +3132,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
             if (callback != m_pOnXmlEvent->end()) {
                 bRet = callback->second(msg);
             }
-            if (weakflag.expired()) {
+            if (weakflag.expired() || msg.IsSenderExpired()) {
                 return false;
             }
         }
@@ -3119,7 +3143,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
         if (callback != m_pOnBubbledEvent->end()) {
             bRet = callback->second(msg);
         }
-        if (weakflag.expired()) {
+        if (weakflag.expired() || msg.IsSenderExpired()) {
             return false;
         }
 
@@ -3127,7 +3151,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
         if (callback != m_pOnBubbledEvent->end()) {
             bRet = callback->second(msg);
         }
-        if (weakflag.expired()) {
+        if (weakflag.expired() || msg.IsSenderExpired()) {
             return false;
         }
     }
@@ -3137,7 +3161,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
         if (callback != m_pOnXmlBubbledEvent->end()) {
             bRet = callback->second(msg);
         }
-        if (weakflag.expired()) {
+        if (weakflag.expired() || msg.IsSenderExpired()) {
             return false;
         }
 
@@ -3145,7 +3169,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
         if (callback != m_pOnXmlBubbledEvent->end()) {
             bRet = callback->second(msg);
         }
-        if (weakflag.expired()) {
+        if (weakflag.expired() || msg.IsSenderExpired()) {
             return false;
         }
     }

--- a/duilib/Core/ControlDragable.h
+++ b/duilib/Core/ControlDragable.h
@@ -349,6 +349,9 @@ bool ControlDragableT<T>::ButtonDown(const EventArgs& msg)
 {
     m_bMouseDown = false;
     bool bRet = __super::ButtonDown(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (!IsEnableDragOrder() && !IsEnableDragOut()) {
         return bRet;
     }
@@ -388,6 +391,9 @@ template<typename T>
 bool ControlDragableT<T>::ButtonUp(const EventArgs& msg)
 {
     bool bRet = __super::ButtonUp(msg);
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     if (!DragOutMouseUp(msg)) {
         DragOrderMouseUp(msg);
     }

--- a/duilib/Core/EventArgs.cpp
+++ b/duilib/Core/EventArgs.cpp
@@ -1,7 +1,38 @@
 #include "EventArgs.h"
+#include "duilib/Core/Control.h"
 
 namespace ui
 {
+
+void EventArgs::SetSender(Control* pControl)
+{
+    if (pControl != nullptr) {
+        pSender = pControl;
+        m_senderFlag = pControl->GetWeakFlag();
+    }
+    else {
+        pSender = nullptr;
+        m_senderFlag.reset();
+    }
+}
+
+Control* EventArgs::GetSender() const
+{
+    if (m_senderFlag.expired()) {
+        return nullptr;
+    }
+    else {
+        return pSender;
+    }
+}
+
+bool EventArgs::IsSenderExpired() const
+{
+    if (pSender != nullptr) {
+        return m_senderFlag.expired();
+    }
+    return false;
+}
 
 EventType StringToEventType(const DString& messageType)
 {

--- a/duilib/Core/EventArgs.h
+++ b/duilib/Core/EventArgs.h
@@ -5,15 +5,18 @@
 
 #include "duilib/Core/UiPoint.h"
 #include <string>
+#include <memory>
 
 namespace ui
 {
 class Control;
+class WeakFlag;
 
 /** 事件通知的参数
 */
 struct EventArgs
 {
+public:
     EventArgs() :
         Type(kEventNone),
         pSender(nullptr),
@@ -29,10 +32,6 @@ struct EventArgs
     /** 事件类型
     */
     EventType Type;
-
-    /** 发送事件的控件
-    */
-    Control* pSender;
 
     /** 产生事件时的时间戳
     */
@@ -53,6 +52,28 @@ struct EventArgs
     /** 产生事件时的参数
     */
     LPARAM lParam;
+
+public:
+    /** 设置发送事件的控件
+    */
+    void SetSender(Control* pControl);
+
+    /** 获取发送事件的控件
+    */
+    Control* GetSender() const;
+
+    /** 判断发送事件的控件是否失效
+    */
+    bool IsSenderExpired() const;
+
+private:
+    /** 发送事件的控件
+    */
+    Control* pSender;
+
+    /** 控件的生命周期标志
+    */
+    std::weak_ptr<WeakFlag> m_senderFlag;
 };
 
 /** 将字符串转换为事件类型

--- a/duilib/Core/ScrollBar.cpp
+++ b/duilib/Core/ScrollBar.cpp
@@ -213,6 +213,9 @@ void ScrollBar::SetVisible(bool bVisible)
 
 bool ScrollBar::ButtonUp(const EventArgs& msg)
 {
+    if (msg.IsSenderExpired()) {
+        return false;
+    }
     UiPoint pt(msg.ptMouse);
     pt.Offset(GetScrollOffsetInScrollBox());
     bool ret = false;
@@ -245,7 +248,7 @@ bool ScrollBar::HasHotState()
 bool ScrollBar::MouseEnter(const EventArgs& msg)
 {
     bool ret = __super::MouseEnter(msg);
-    if (IsHotState()) {
+    if (IsHotState() && !msg.IsSenderExpired()) {
         m_uButton1State = kControlStateHot;
         m_uButton2State = kControlStateHot;
         m_uThumbState = kControlStateHot;
@@ -256,7 +259,7 @@ bool ScrollBar::MouseEnter(const EventArgs& msg)
 bool ScrollBar::MouseLeave(const EventArgs& msg)
 {
     bool ret = __super::MouseLeave(msg);
-    if (!IsHotState()) {
+    if (!IsHotState() && !msg.IsSenderExpired()) {
         m_uButton1State = kControlStateNormal;
         m_uButton2State = kControlStateNormal;
         m_uThumbState = kControlStateNormal;

--- a/duilib/Image/ImageGif.cpp
+++ b/duilib/Image/ImageGif.cpp
@@ -162,7 +162,7 @@ void ImageGif::BroadcastGifEvent(int32_t nVirtualEvent) const
     auto callback = m_OnGifEvent.find(nVirtualEvent);
     if (callback != m_OnGifEvent.end()) {
         EventArgs param;
-        param.pSender = m_pControl;
+        param.SetSender(m_pControl);
         callback->second(param);
     }
 }

--- a/duilib/Utils/Delegate.h
+++ b/duilib/Utils/Delegate.h
@@ -17,9 +17,12 @@ typedef std::function<bool(const ui::EventArgs&)> EventCallback;
 class CEventSource : public std::vector<EventCallback>
 {
 public:
-    CEventSource& operator += (const EventCallback& item) 
+    CEventSource& operator += (const EventCallback& callback)
     {
-        push_back(item);
+        ASSERT(callback != nullptr);
+        if (callback != nullptr) {
+            push_back(callback);
+        }        
         return *this;
     }
 
@@ -27,8 +30,11 @@ public:
     {
         //支持在回调函数中，操作此容器
         for (size_t index = 0; index < this->size(); ++index) {
+            if (param.IsSenderExpired()) {
+                return false;
+            }
             EventCallback callback = this->at(index);
-            if (!callback(param)) {
+            if ((callback == nullptr) || !callback(param)) {
                 return false;
             }
         }

--- a/duilib/Utils/WinImplBase.cpp
+++ b/duilib/Utils/WinImplBase.cpp
@@ -167,11 +167,12 @@ bool WindowImplBase::OnButtonClick(const EventArgs& msg)
     if (IsUseSystemCaption()) {
         return true;
     }
-    ASSERT(msg.pSender != nullptr);
-    if (msg.pSender == nullptr) {
+    Control* pSender = msg.GetSender();
+    ASSERT(pSender != nullptr);
+    if (pSender == nullptr) {
         return false;
     }
-    DString sCtrlName = msg.pSender->GetName();
+    DString sCtrlName = pSender->GetName();
     if (sCtrlName == DUI_CTR_BUTTON_CLOSE) {
         //关闭按钮
         CloseWnd();

--- a/examples/ListCtrl/MainForm.cpp
+++ b/examples/ListCtrl/MainForm.cpp
@@ -480,7 +480,7 @@ void MainForm::OnInitWindow()
 
     //事件挂载，测试事件接口
     auto OnListCtrlEvent = [this, pListCtrl](const ui::EventArgs& args) {
-            ASSERT(pListCtrl == args.pSender);
+            ASSERT(pListCtrl == args.GetSender());
             ui::ListCtrlItem* pItem = (ui::ListCtrlItem*)args.wParam;
             size_t itemIndex = args.lParam;
             ui::UiPoint mousePt = args.ptMouse;

--- a/examples/MultiLang/MainForm.cpp
+++ b/examples/MultiLang/MainForm.cpp
@@ -37,7 +37,7 @@ void MainForm::OnInitWindow()
         return;
     }
     select->AttachClick([this](const ui::EventArgs& args) {
-        ui::UiRect rect = args.pSender->GetPos();
+        ui::UiRect rect = args.GetSender()->GetPos();
         ui::UiPoint point;
         point.x = rect.left;
         point.y = rect.bottom;

--- a/examples/RichEdit/FindForm.cpp
+++ b/examples/RichEdit/FindForm.cpp
@@ -62,7 +62,7 @@ void FindForm::OnInitWindow()
     ui::Button* pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_cancel")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     CloseWnd();
                 }
                 return true;
@@ -71,7 +71,7 @@ void FindForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_find_next")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     OnFindNext();
                 }
                 return true;

--- a/examples/RichEdit/MainForm.cpp
+++ b/examples/RichEdit/MainForm.cpp
@@ -44,7 +44,7 @@ void MainForm::OnInitWindow()
     if (pRichEdit != nullptr) {
         pRichEdit->AttachLinkClick([this, pRichEdit](const ui::EventArgs& args) {
                 //点击了超级链接
-                if (args.pSender == pRichEdit) {
+                if (args.GetSender() == pRichEdit) {
                     const wchar_t* pUrl = (const wchar_t*)args.wParam;
                     if (pUrl != nullptr) {
                         ::ShellExecute(GetHWND(), _T("open"), pUrl, NULL, NULL, SW_SHOWNORMAL);
@@ -62,7 +62,7 @@ void MainForm::OnInitWindow()
     ui::Button* pButton = dynamic_cast<ui::Button*>(FindControl(_T("open_file")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     this->OnOpenFile();
                 }
                 return true;
@@ -72,7 +72,7 @@ void MainForm::OnInitWindow()
     if (pButton != nullptr) {
         m_saveBtnText = pButton->GetText();
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     this->OnSaveFile();
                 }
                 return true;
@@ -81,7 +81,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("save_as_file")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     this->OnSaveAsFile();
                 }
                 return true;
@@ -92,7 +92,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_copy")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->Copy();
                     UpdateSaveStatus();
@@ -104,7 +104,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_cut")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->Cut();
                     UpdateSaveStatus();
@@ -116,7 +116,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_paste")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->Paste();
                     UpdateSaveStatus();
@@ -128,7 +128,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_delete")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->Clear();
                     UpdateSaveStatus();
@@ -140,7 +140,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_sel_all")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->SetSelAll();
                     UpdateSaveStatus();
@@ -152,7 +152,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_sel_none")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->SetSelNone();
                     UpdateSaveStatus();
@@ -164,7 +164,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_undo")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->Undo();
                     UpdateSaveStatus();
@@ -176,7 +176,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_redo")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 if (m_pRichEdit != nullptr) {
                     m_pRichEdit->Redo();
                     UpdateSaveStatus();
@@ -190,7 +190,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_find_text")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 OnFindText();
             }
             return true;
@@ -199,7 +199,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_find_next")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 OnFindNext();
             }
             return true;
@@ -208,7 +208,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_replace_text")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 OnReplaceText();
             }
             return true;
@@ -219,7 +219,7 @@ void MainForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("set_font")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-            if (args.pSender == pButton) {
+            if (args.GetSender() == pButton) {
                 OnSetFont();
             }
             return true;

--- a/examples/RichEdit/ReplaceForm.cpp
+++ b/examples/RichEdit/ReplaceForm.cpp
@@ -66,7 +66,7 @@ void ReplaceForm::OnInitWindow()
     ui::Button* pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_cancel")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     CloseWnd();
                 }
                 return true;
@@ -75,7 +75,7 @@ void ReplaceForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_find_next")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     OnFindNext();
                 }
                 return true;
@@ -84,7 +84,7 @@ void ReplaceForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_replace")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     OnReplace();
                 }
                 return true;
@@ -93,7 +93,7 @@ void ReplaceForm::OnInitWindow()
     pButton = dynamic_cast<ui::Button*>(FindControl(_T("btn_replace_all")));
     if (pButton != nullptr) {
         pButton->AttachClick([this, pButton](const ui::EventArgs& args) {
-                if (args.pSender == pButton) {
+                if (args.GetSender() == pButton) {
                     OnReplaceAll();
                 }
                 return true;

--- a/examples/TreeView/FileInfoList.cpp
+++ b/examples/TreeView/FileInfoList.cpp
@@ -95,7 +95,7 @@ void FileInfoList::ClearFileList()
 
 bool FileInfoList::OnDoubleClickItem(const ui::EventArgs& args)
 {
-    FileInfoItem* pItem = dynamic_cast<FileInfoItem*>(args.pSender);
+    FileInfoItem* pItem = dynamic_cast<FileInfoItem*>(args.GetSender());
     if (pItem != nullptr) {
         size_t nElementIndex = pItem->GetUserDataID();
         if (nElementIndex < m_pathList.size()) {

--- a/examples/TreeView/MainForm.cpp
+++ b/examples/TreeView/MainForm.cpp
@@ -262,7 +262,7 @@ ui::TreeNode* MainForm::ShowAllDiskNode()
 
 bool MainForm::OnTreeNodeExpand(const ui::EventArgs& args)
 {
-    ui::TreeNode* pTreeNode = dynamic_cast<ui::TreeNode*>(args.pSender);
+    ui::TreeNode* pTreeNode = dynamic_cast<ui::TreeNode*>(args.GetSender());
     ASSERT(pTreeNode != nullptr);
     if (pTreeNode != nullptr) {
         FolderStatus* pFolder = (FolderStatus*)pTreeNode->GetUserDataID();
@@ -393,7 +393,7 @@ void MainForm::ShowSubFolders(ui::TreeNode* pTreeNode, const DString& path)
 
 bool MainForm::OnTreeNodeClick(const ui::EventArgs& args)
 {
-    ui::TreeNode* pTreeNode = dynamic_cast<ui::TreeNode*>(args.pSender);
+    ui::TreeNode* pTreeNode = dynamic_cast<ui::TreeNode*>(args.GetSender());
     ASSERT(pTreeNode != nullptr);
     if (pTreeNode != nullptr) {
         FolderStatus* pFolder = (FolderStatus*)pTreeNode->GetUserDataID();

--- a/examples/VirtualListBox/main_form.cpp
+++ b/examples/VirtualListBox/main_form.cpp
@@ -77,7 +77,7 @@ void MainForm::OnCloseWindow()
 
 bool MainForm::OnClicked(const ui::EventArgs& args)
 {
-    auto sName = args.pSender->GetName();
+    auto sName = args.GetSender()->GetName();
     if (sName == _T("btn_set_total"))
     {
         if (!m_EditChildMarginX->GetText().empty())    {

--- a/examples/cef/cef_form.cpp
+++ b/examples/cef/cef_form.cpp
@@ -75,7 +75,7 @@ void CefForm::OnCloseWindow()
 
 bool CefForm::OnClicked(const ui::EventArgs& msg)
 {
-    DString name = msg.pSender->GetName();
+    DString name = msg.GetSender()->GetName();
 
     if (name == _T("btn_dev_tool"))
     {

--- a/examples/controls/controls_form.cpp
+++ b/examples/controls/controls_form.cpp
@@ -122,7 +122,7 @@ void ControlForm::OnInitWindow()
     /* Show settings menu */
     ui::Button* settings = static_cast<ui::Button*>(FindControl(_T("settings")));
     settings->AttachClick([this](const ui::EventArgs& args) {
-        ui::UiRect rect = args.pSender->GetPos();
+        ui::UiRect rect = args.GetSender()->GetPos();
         ui::UiPoint point;
         point.x = rect.left - 175;
         point.y = rect.top + 10;

--- a/examples/multi_browser/browser/multi_browser_form.cpp
+++ b/examples/multi_browser/browser/multi_browser_form.cpp
@@ -213,7 +213,7 @@ void MultiBrowserForm::OnWndSizeMax(bool max)
 
 bool MultiBrowserForm::OnClicked(const ui::EventArgs& arg )
 {
-    DString name = arg.pSender->GetName();
+    DString name = arg.GetSender()->GetName();
     if (name == _T("btn_max_restore"))
     {
         DWORD style = GetWindowLong(GetHWND(), GWL_STYLE);
@@ -267,7 +267,7 @@ bool MultiBrowserForm::OnClicked(const ui::EventArgs& arg )
 
 bool MultiBrowserForm::OnReturn(const ui::EventArgs& arg)
 {
-    DString name = arg.pSender->GetName();
+    DString name = arg.GetSender()->GetName();
     if (name == _T("edit_url"))
     {
 #if 0
@@ -587,7 +587,7 @@ bool MultiBrowserForm::OnTabItemSelected(const ui::EventArgs& param)
 {
     if (kEventSelect == param.Type)
     {
-        DString name = param.pSender->GetName();
+        DString name = param.GetSender()->GetName();
 
         if (name == _T("tab_list"))
         {
@@ -603,7 +603,7 @@ bool MultiBrowserForm::OnTabItemSelected(const ui::EventArgs& param)
     }
     else if (kEventMouseButtonDown == param.Type)
     {
-        BrowserTabItem *tab_item = dynamic_cast<BrowserTabItem*>(param.pSender);
+        BrowserTabItem *tab_item = dynamic_cast<BrowserTabItem*>(param.GetSender());
         if (tab_item)
         {
             DString browser_id = tab_item->GetName();
@@ -615,7 +615,7 @@ bool MultiBrowserForm::OnTabItemSelected(const ui::EventArgs& param)
 
 bool MultiBrowserForm::OnTabItemClose(const ui::EventArgs& param, const std::string& browser_id)
 {
-    if (param.pSender->GetName() == _T("tab_item_close"))
+    if (param.GetSender()->GetName() == _T("tab_item_close"))
     {
         CloseBox(browser_id);
     }

--- a/ui_components/msgbox/msgbox.cpp
+++ b/ui_components/msgbox/msgbox.cpp
@@ -89,8 +89,8 @@ void MsgBox::OnInitWindow()
 bool MsgBox::OnClicked(const ui::EventArgs& msg)
 {
     DString name;
-    if (msg.pSender != nullptr) {
-        name = msg.pSender->GetName();
+    if (msg.GetSender() != nullptr) {
+        name = msg.GetSender()->GetName();
     }
     if (name == _T("btn_yes")) {
         EndMsgBox(MB_YES);

--- a/ui_components/toast/toast.cpp
+++ b/ui_components/toast/toast.cpp
@@ -100,8 +100,8 @@ void Toast::SetDuration(int duration)
 bool Toast::OnClicked(const ui::EventArgs& msg)
 {
     DString name;
-    if (msg.pSender != nullptr) {
-        name = msg.pSender->GetName();
+    if (msg.GetSender() != nullptr) {
+        name = msg.GetSender()->GetName();
     }
     if (name == _T("close_btn")) {
         this->CloseWnd();


### PR DESCRIPTION
Fix Issue #19: Menu内绑定鼠标单击处理函数 调用fileDlg.BrowseForFile 或GetOpenFileName 连续两次或三次就会触发异常。
问题原因：鼠标点击事件中，如果弹出式窗口，菜单窗口或者控件资源被释放，当对弹出式窗口关闭后，会出现访问非法指针的现象，导致崩溃。 修复方法：对消息中的控件，增加生命周期保护策略，当检测到控件资源被释放，则避免访问该资源。

