### PR TITLE
Fix Issue #28: When using the colorpicker to pick a color from the screen, the program crashes.

### DIFF
--- a/duilib/Control/ColorPicker.cpp
+++ b/duilib/Control/ColorPicker.cpp
@@ -627,7 +627,8 @@ private:
                         }
                         int32_t colorXY = nRow * nWidth + nColumn;
                         ASSERT(colorXY < nWidth * nHeight);
-                        pDestPixelBits[++destColorIndex] = pPixelBits[colorXY];
+                        ASSERT(destColorIndex < (int32_t)spBitmap->GetWidth() * (int32_t)spBitmap->GetHeight());
+                        pDestPixelBits[destColorIndex++] = pPixelBits[colorXY];
                     }
                 }
             }


### PR DESCRIPTION
Fix Issue #28: When using the colorpicker to pick a color from the screen, the program crashes.
