### PR TITLE
输入法管理相关的机制调整

### DIFF
--- a/duilib/CEFControl/CefControlNative.cpp
+++ b/duilib/CEFControl/CefControlNative.cpp
@@ -140,31 +140,22 @@ void CefControlNative::SetPos(ui::UiRect rc)
 #endif
 }
 
-void CefControlNative::HandleEvent(const ui::EventArgs& msg)
+bool CefControlNative::OnSetFocus(const EventArgs& msg)
 {
-    if (IsDisabledEvents(msg)) {
-        //如果是鼠标键盘消息，并且控件是Disabled的，转发给上层控件
-        ui::Box* pParent = GetParent();
-        if (pParent != nullptr) {
-            pParent->SendEventMsg(msg);
-        }
-        else {
-            BaseClass::HandleEvent(msg);
-        }
-        return;
+    CefRefPtr<CefBrowserHost> browserHost = GetCefBrowserHost();
+    if (browserHost != nullptr) {
+        browserHost->SetFocus(true);
     }
-    if (m_pBrowserHandler.get() && m_pBrowserHandler->GetBrowser().get() == nullptr) {
-        BaseClass::HandleEvent(msg);
-        return;
-    }
+    return BaseClass::OnSetFocus(msg);
+}
 
-    else if (msg.eventType == ui::kEventSetFocus) {
-        m_pBrowserHandler->GetBrowserHost()->SetFocus(true);
+bool CefControlNative::OnKillFocus(const EventArgs& msg)
+{
+    CefRefPtr<CefBrowserHost> browserHost = GetCefBrowserHost();
+    if (browserHost != nullptr) {
+        browserHost->SetFocus(false);
     }
-    else if (msg.eventType == ui::kEventKillFocus) {
-        m_pBrowserHandler->GetBrowserHost()->SetFocus(false);
-    }
-    BaseClass::HandleEvent(msg);
+    return BaseClass::OnKillFocus(msg);
 }
 
 #ifdef DUILIB_BUILD_FOR_LINUX

--- a/duilib/CEFControl/CefControlNative.h
+++ b/duilib/CEFControl/CefControlNative.h
@@ -21,7 +21,8 @@ public:
 
     virtual void Init() override;
     virtual void SetPos(ui::UiRect rc) override;
-    virtual void HandleEvent(const ui::EventArgs& msg) override;
+    virtual bool OnSetFocus(const EventArgs& msg);
+    virtual bool OnKillFocus(const EventArgs& msg);
     virtual void SetVisible(bool bVisible) override;
     virtual void SetWindow(ui::Window* pWindow) override;
 

--- a/duilib/CEFControl/CefControlOffScreen.cpp
+++ b/duilib/CEFControl/CefControlOffScreen.cpp
@@ -155,37 +155,6 @@ void CefControlOffScreen::SetPos(UiRect rc)
     }
 }
 
-void CefControlOffScreen::HandleEvent(const EventArgs& msg)
-{
-    if (IsDisabledEvents(msg)) {
-        //如果是鼠标键盘消息，并且控件是Disabled的，转发给上层控件
-        Box* pParent = GetParent();
-        if (pParent != nullptr) {
-            pParent->SendEventMsg(msg);
-        }
-        else {
-            BaseClass::HandleEvent(msg);
-        }
-        return;
-    }
-    if (m_pBrowserHandler.get() && m_pBrowserHandler->GetBrowser().get() == nullptr) {
-        return BaseClass::HandleEvent(msg);
-    }
-
-    else if (msg.eventType == kEventSetFocus) {
-        if (m_pBrowserHandler->GetBrowserHost().get()) {
-            m_pBrowserHandler->GetBrowserHost()->SetFocus(true);
-        }
-    }
-    else if (msg.eventType == kEventKillFocus) {
-        if (m_pBrowserHandler->GetBrowserHost().get()) {
-            m_pBrowserHandler->GetBrowserHost()->SetFocus(false);
-        }
-    }
-
-    BaseClass::HandleEvent(msg);
-}
-
 void CefControlOffScreen::SetVisible(bool bVisible)
 {
     GlobalManager::Instance().AssertUIThread();
@@ -525,6 +494,24 @@ void CefControlOffScreen::SendButtonDoubleClickEvent(const EventArgs& msg)
         (msg.eventType == kEventMouseDoubleClick ? MBT_LEFT : (
             msg.eventType == kEventMouseRDoubleClick ? MBT_RIGHT : MBT_MIDDLE));
     host->SendMouseClickEvent(mouse_event, btnType, true, 2);
+}
+
+bool CefControlOffScreen::OnSetFocus(const EventArgs& msg)
+{
+    CefRefPtr<CefBrowserHost> browserHost = GetCefBrowserHost();
+    if (browserHost != nullptr) {
+        browserHost->SetFocus(true);
+    }
+    return BaseClass::OnSetFocus(msg);
+}
+
+bool CefControlOffScreen::OnKillFocus(const EventArgs& msg)
+{
+    CefRefPtr<CefBrowserHost> browserHost = GetCefBrowserHost();
+    if (browserHost != nullptr) {
+        browserHost->SetFocus(false);
+    }
+    return BaseClass::OnKillFocus(msg);
 }
 
 bool CefControlOffScreen::OnChar(const EventArgs& msg)

--- a/duilib/CEFControl/CefControlOffScreen.h
+++ b/duilib/CEFControl/CefControlOffScreen.h
@@ -32,7 +32,6 @@ public:
     /// 重写父类接口，提供个性化功能
     virtual void Init() override;
     virtual void SetPos(UiRect rc) override;
-    virtual void HandleEvent(const ui::EventArgs& msg) override;
     virtual void SetVisible(bool bVisible) override;
     virtual void Paint(IRender* pRender, const UiRect& rcPaint) override;
     virtual void SetWindow(Window* pWindow) override;
@@ -71,6 +70,10 @@ protected:
     virtual bool MButtonDown(const EventArgs& msg) override;
     virtual bool MButtonUp(const EventArgs& msg) override;
     virtual bool MButtonDoubleClick(const EventArgs& msg) override;
+
+    //焦点相关消息处理
+    virtual bool OnSetFocus(const EventArgs& msg);
+    virtual bool OnKillFocus(const EventArgs& msg);
 
     //键盘消息（返回true：表示消息已处理；返回false：则表示消息未处理，需转发给父控件）
     virtual bool OnChar(const EventArgs& msg) override;

--- a/duilib/CEFControl/internal/CefBrowserHandler.cpp
+++ b/duilib/CEFControl/internal/CefBrowserHandler.cpp
@@ -467,6 +467,7 @@ void CefBrowserHandler::OnImeCompositionRangeChanged(CefRefPtr<CefBrowser> brows
                                                      const CefRange& selected_range,
                                                      const RectList& character_bounds)
 {
+    //此函数只有OSR模式会有回调事件
     if (m_pHandlerDelegate) {
         m_pHandlerDelegate->OnImeCompositionRangeChanged(browser, selected_range, character_bounds);
     }
@@ -818,27 +819,6 @@ bool CefBrowserHandler::OnKeyEvent(CefRefPtr<CefBrowser> browser, const CefKeyEv
         m_pHandlerDelegate->OnKeyEvent(browser, event, os_event);
     }
     return false;
-}
-
-void CefBrowserHandler::OnTakeFocus(CefRefPtr<CefBrowser> browser, bool next)
-{
-
-}
-
-bool CefBrowserHandler::OnSetFocus(CefRefPtr<CefBrowser> browser, cef_focus_source_t source)
-{
-    return false;
-}
-
-void CefBrowserHandler::OnGotFocus(CefRefPtr<CefBrowser> browser)
-{
-#ifdef DUILIB_BUILD_FOR_WIN
-    //修正首次显示页面时，中文输入法的输入框显示位置错误问题，原因是此时的焦点窗口不正确
-    HWND hHostWnd = browser->GetHost()->GetWindowHandle();
-    if (::IsWindow(hHostWnd) && (hHostWnd != ::GetFocus())) {
-        ::SetFocus(hHostWnd);
-    }
-#endif
 }
 
 // CefRequestHandler methods

--- a/duilib/CEFControl/internal/CefBrowserHandler.h
+++ b/duilib/CEFControl/internal/CefBrowserHandler.h
@@ -50,7 +50,6 @@ class CefBrowserHandler : public virtual ui::SupportWeakCallback,
     public CefCookieAccessFilter,
     public CefDownloadHandler,
     public CefDialogHandler,
-    public CefFocusHandler,
     public client::OsrDragEvents
 {
 public:
@@ -92,8 +91,8 @@ public:
     virtual CefRefPtr<CefFrameHandler> GetFrameHandler() override { return nullptr; }
     virtual CefRefPtr<CefPermissionHandler> GetPermissionHandler() override { return nullptr; }
     virtual CefRefPtr<CefPrintHandler> GetPrintHandler() override { return nullptr; }
+    virtual CefRefPtr<CefFocusHandler> GetFocusHandler() override { return nullptr; }
 
-    virtual CefRefPtr<CefFocusHandler> GetFocusHandler() override { return this; }
     virtual CefRefPtr<CefContextMenuHandler> GetContextMenuHandler() override {    return this; }
     virtual CefRefPtr<CefRenderHandler>  GetRenderHandler() override { return this; }
     virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() override{ return this; }
@@ -400,11 +399,6 @@ public:
                               const std::vector<CefString>& accept_descriptions,
                               CefRefPtr<CefFileDialogCallback> callback) override;
 #endif
-
-    //CefFocusHandler接口的实现
-    virtual void OnTakeFocus(CefRefPtr<CefBrowser> browser, bool next) override;
-    virtual bool OnSetFocus(CefRefPtr<CefBrowser> browser, cef_focus_source_t source) override;
-    virtual void OnGotFocus(CefRefPtr<CefBrowser> browser) override;
 
 private:
     bool DoOnBeforePopup(CefRefPtr<CefBrowser> browser,

--- a/duilib/Control/RichEdit_SDL.cpp
+++ b/duilib/Control/RichEdit_SDL.cpp
@@ -1520,10 +1520,8 @@ void RichEdit::SetImmStatus(BOOL bOpen)
     if (hwnd == nullptr) {
         return;
     }
-    // 失去焦点时关闭输入法
+    //失去焦点时关闭输入法(避免出现当焦点为其他非输入控件时，也能使用中文输入法但无法使输入的文字上屏的问题)
     HIMC hImc = ::ImmGetContext(hwnd);
-    // 失去焦点是会把关联的输入法去掉，导致无法无法输入中文
-    //::ImmAssociateContext(hwnd, bOpen ? hImc : nullptr);
     if (hImc != nullptr) {
         if (::ImmGetOpenStatus(hImc)) {
             if (!bOpen) {
@@ -3259,7 +3257,18 @@ bool RichEdit::OnKillFocus(const EventArgs& /*msg*/)
     }
 
 #if defined (DUILIB_BUILD_FOR_WIN) && !defined (DUILIB_BUILD_FOR_SDL)
-    SetImmStatus(FALSE);
+    HWND hWnd = GetWindowHWND();
+    HWND hFocusWnd = ::GetFocus();
+    bool bNewFocusIsChildWnd = false;
+    if ((hFocusWnd != hWnd) && ::IsWindow(hWnd) && ::IsWindow(hFocusWnd)) {
+        if (::IsChild(hWnd, hFocusWnd)) {
+            bNewFocusIsChildWnd = true;
+        }
+    }
+    if (!bNewFocusIsChildWnd) {
+        //如果新的焦点窗口为当前窗口的子窗口，不关闭输入法，其他情况才关闭输入法
+        SetImmStatus(FALSE);
+    }
 #endif
 
 #ifdef DUILIB_BUILD_FOR_SDL

--- a/duilib/Control/RichEdit_SDL.h
+++ b/duilib/Control/RichEdit_SDL.h
@@ -958,10 +958,6 @@ private:
     /** 获取关联的窗口局部
     */
     HWND GetWindowHWND() const;
-
-    /** 设置输入法状态
-    */
-    void SetImmStatus(BOOL bOpen);
 #endif
 
 private:

--- a/duilib/Control/RichEdit_Windows.h
+++ b/duilib/Control/RichEdit_Windows.h
@@ -1025,10 +1025,6 @@ private:
     */
     UiSize GetNaturalSize(LONG width, LONG height);
 
-    /** 设置输入法状态
-    */
-    void SetImmStatus(BOOL bOpen);
-
     /** 设置一个定时器（由内部回调使用）
     */
     void SetTimer(UINT idTimer, UINT uTimeout);

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -1762,11 +1762,16 @@ void Control::HandleEvent(const EventArgs& msg)
             return;
         }
     }
+    else if (msg.eventType == kEventWindowSetFocus) {
+        if (OnWindowSetFocus(msg)) {
+            return;
+        }
+    }
     else if (msg.eventType == kEventWindowKillFocus) {
         if (OnWindowKillFocus(msg)) {
             return;
         }
-    }
+    }    
     else if (msg.eventType == kEventCaptureChanged) {
         if (OnCaptureChanged(msg)) {
             return;
@@ -2111,6 +2116,14 @@ void Control::SetCursor(CursorType cursorType)
 
 bool Control::OnSetFocus(const EventArgs& /*msg*/)
 {
+#if defined (DUILIB_BUILD_FOR_WIN)
+    //默认情况下，控件获得焦点时，关闭输入法
+    Window* pWindow = GetWindow();
+    if (pWindow != nullptr) {
+        pWindow->NativeWnd()->SetImeOpenStatus(false);
+    }
+#endif
+
     if (GetState() == kControlStateNormal) {
         SetState(kControlStateHot);
         Invalidate();
@@ -2137,6 +2150,12 @@ bool Control::OnKillFocus(const EventArgs& msg)
     }
     Invalidate();
     return true;
+}
+
+bool Control::OnWindowSetFocus(const EventArgs& /*msg*/)
+{
+    //默认不处理，交由父控件处理
+    return false;
 }
 
 bool Control::OnWindowKillFocus(const EventArgs& /*msg*/)

--- a/duilib/Core/Control.h
+++ b/duilib/Core/Control.h
@@ -1042,6 +1042,7 @@ protected:
     virtual bool OnSetCursor(const EventArgs& msg);
     virtual bool OnSetFocus(const EventArgs& msg);
     virtual bool OnKillFocus(const EventArgs& msg); //控件失去焦点
+    virtual bool OnWindowSetFocus(const EventArgs& msg);//控件所属的窗口获得焦点
     virtual bool OnWindowKillFocus(const EventArgs& msg);//控件所属的窗口失去焦点
     virtual bool OnCaptureChanged(const EventArgs& msg);//控件所属窗口的鼠标捕获丢失
     virtual bool OnImeSetContext(const EventArgs& msg);

--- a/duilib/Core/EventArgs.cpp
+++ b/duilib/Core/EventArgs.cpp
@@ -216,6 +216,8 @@ DString EventTypeToString(EventType eventType)
         return _T("kEventImeComposition");
     case kEventImeEndComposition:
         return _T("kEventImeEndComposition");
+    case kEventWindowSetFocus:
+        return _T("kEventWindowSetFocus");
     case kEventWindowKillFocus:
         return _T("kEventWindowKillFocus");
     case kEventWindowSize:

--- a/duilib/Core/NativeWindow_Windows.cpp
+++ b/duilib/Core/NativeWindow_Windows.cpp
@@ -2701,23 +2701,19 @@ bool NativeWindow_Windows::IsEnableSysMenu() const
 
 void NativeWindow_Windows::SetImeOpenStatus(bool bOpen)
 {
-    HWND hwnd = m_hWnd;
-    if (!::IsWindow(hwnd)) {
-        return;
-    }
-
     if (!bOpen) {
         //禁用输入法
-        EnableIME(hwnd, false);
+        EnableIME(m_hWnd, false);
     }
     else {
         //启用输入法
-        EnableIME(hwnd, true);
+        EnableIME(m_hWnd, true);
     }
 }
 
 void NativeWindow_Windows::EnableIME(HWND hwnd, bool bEnable)
 {
+    ASSERT(::IsWindow(hwnd));
     if (!::IsWindow(hwnd)) {
         return;
     }
@@ -2734,6 +2730,18 @@ void NativeWindow_Windows::EnableIME(HWND hwnd, bool bEnable)
             HIMC hImc = ::ImmAssociateContext(hwnd, m_hImc);
             m_hImc = nullptr;
             ASSERT(hImc == nullptr);
+        }
+        else {
+            //检查输入法是否打开，给出断言
+            HIMC hImc = ::ImmGetContext(hwnd);
+            ASSERT(hImc != nullptr);
+            if (hImc != nullptr) {
+                ASSERT(::ImmGetOpenStatus(hImc));
+                if (!::ImmGetOpenStatus(hImc)) {
+                    ::ImmSetOpenStatus(hImc, TRUE);
+                }
+                ::ImmReleaseContext(hwnd, hImc);
+            }
         }
     }
 }

--- a/duilib/Core/NativeWindow_Windows.h
+++ b/duilib/Core/NativeWindow_Windows.h
@@ -454,6 +454,11 @@ public:
     */
     LRESULT CallDefaultWindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
+    /** 设置输入法的开关状态（关闭再打开以后，能够保持原输入法状态）
+    * @param [in] bOpen true标识打开输入法，false标识关闭输入法
+    */
+    void SetImeOpenStatus(bool bOpen);
+
 private:
     /** 窗口过程函数
     * @param [in] hWnd 窗口句柄
@@ -590,6 +595,10 @@ private:
     */
     bool CalculateCenterWindowPos(HWND hCenterWindow, int32_t& xPos, int32_t& yPos) const;
 
+    /** 启用/禁用输入法
+    */
+    void EnableIME(HWND hwnd, bool bEnable);
+
 private:
     /** 接收窗口事件的接口
     */
@@ -692,6 +701,10 @@ private:
     /** 窗口大小的最大值（宽度和高度）
     */
     UiSize m_szMaxWindow;
+
+    /** 输入法的上下文
+    */
+    HIMC m_hImc;
 };
 
 /** 定义别名

--- a/duilib/Core/Window.cpp
+++ b/duilib/Core/Window.cpp
@@ -56,6 +56,16 @@ void Window::AttachWindowClose(const EventCallback& callback)
     m_OnEvent[kEventWindowClose] += callback;
 }
 
+void Window::AttachWindowSetFocus(const EventCallback& callback)
+{
+    m_OnEvent[kEventWindowSetFocus] += callback;
+}
+
+void Window::AttachWindowKillFocus(const EventCallback& callback)
+{
+    m_OnEvent[kEventWindowKillFocus] += callback;
+}
+
 bool Window::SetRenderBackendType(RenderBackendType backendType)
 {
 #if defined (DUILIB_BUILD_FOR_WIN) && !defined (DUILIB_BUILD_FOR_SDL)
@@ -1095,13 +1105,14 @@ bool Window::Paint(const UiRect& rcPaint)
     return true;
 }
 
-LRESULT Window::OnSetFocusMsg(WindowBase* /*pLostFocusWindow*/, const NativeMsg& /*nativeMsg*/, bool& bHandled)
+LRESULT Window::OnSetFocusMsg(WindowBase* /*pLostFocusWindow*/, const NativeMsg& nativeMsg, bool& bHandled)
 {
     bHandled = false;
+    SendNotify(kEventWindowSetFocus, nativeMsg.wParam);
     return 0;
 }
 
-LRESULT Window::OnKillFocusMsg(WindowBase* /*pSetFocusWindow*/, const NativeMsg& /*nativeMsg*/, bool& bHandled)
+LRESULT Window::OnKillFocusMsg(WindowBase* /*pSetFocusWindow*/, const NativeMsg& nativeMsg, bool& bHandled)
 {
     bHandled = false;
     Control* pEventClick = m_pEventClick;
@@ -1121,6 +1132,10 @@ LRESULT Window::OnKillFocusMsg(WindowBase* /*pSetFocusWindow*/, const NativeMsg&
         if (windowFlag.expired()) {
             return 0;
         }
+    }
+
+    if (!windowFlag.expired()) {
+        SendNotify(kEventWindowKillFocus, nativeMsg.wParam);
     }
     return 0;
 }

--- a/duilib/Core/Window.h
+++ b/duilib/Core/Window.h
@@ -854,6 +854,10 @@ private:
     */
     void ParseWindowXml();
 
+    /** 焦点控件发生变化
+    */
+    void OnFocusControlChanged();
+
 private:
     //事件回调管理器
     EventMap m_OnEvent;

--- a/duilib/Core/Window.h
+++ b/duilib/Core/Window.h
@@ -77,6 +77,16 @@ public:
     */
     void AttachWindowClose(const EventCallback& callback);
 
+    /** 监听窗口获取焦点事件
+    * @param [in] callback 指定的回调函数
+    */
+    void AttachWindowSetFocus(const EventCallback& callback);
+
+    /** 监听窗口失去焦点事件
+    * @param [in] callback 指定的回调函数
+    */
+    void AttachWindowKillFocus(const EventCallback& callback);
+
     /** 主动发起一个消息, 发送给该窗口的事件回调管理器（m_OnEvent）中注册的消息处理函数
     * @param [in] eventType 转化后的消息体
     * @param [in] wParam 消息附加参数

--- a/duilib/duilib_defs.h
+++ b/duilib/duilib_defs.h
@@ -299,7 +299,7 @@ namespace ui
         kEventImeComposition,       //Window类：发送给Focus控件，当收到系统WM_IME_COMPOSITION消息时触发
         kEventImeEndComposition,    //Window类：发送给Focus控件，当收到系统WM_IME_ENDCOMPOSITION消息时触发
 
-        kEventWindowSetFocus,       //Window类：发送给接收者的回调函数（wParam: 已失去键盘焦点的窗口的句柄）
+        kEventWindowSetFocus,       //Window类：发送给焦点控件，当窗口获得焦点时触发事件；发送给接收者的回调函数（wParam: 已失去键盘焦点的窗口的句柄）
         kEventWindowKillFocus,      //Window类：发送给鼠标左键、右键按下时记录的控件、焦点控件，当窗口失去焦点时触发事件（主要用于恢复一些内部状态）；发送给接收者的回调函数（wParam: 接收键盘焦点的窗口的句柄）
         kEventWindowSize,           //Window类：发送给Focus控件，当窗口大小发生变化时触发事件
         kEventWindowMove,           //Window类：发送给Focus控件，当窗口大小发生变化时触发事件

--- a/duilib/duilib_defs.h
+++ b/duilib/duilib_defs.h
@@ -299,7 +299,8 @@ namespace ui
         kEventImeComposition,       //Window类：发送给Focus控件，当收到系统WM_IME_COMPOSITION消息时触发
         kEventImeEndComposition,    //Window类：发送给Focus控件，当收到系统WM_IME_ENDCOMPOSITION消息时触发
 
-        kEventWindowKillFocus,      //Window类：发送给鼠标左键、右键按下时记录的控件、焦点控件，当窗口失去焦点时触发事件（主要用于恢复一些内部状态）
+        kEventWindowSetFocus,       //Window类：发送给接收者的回调函数（wParam: 已失去键盘焦点的窗口的句柄）
+        kEventWindowKillFocus,      //Window类：发送给鼠标左键、右键按下时记录的控件、焦点控件，当窗口失去焦点时触发事件（主要用于恢复一些内部状态）；发送给接收者的回调函数（wParam: 接收键盘焦点的窗口的句柄）
         kEventWindowSize,           //Window类：发送给Focus控件，当窗口大小发生变化时触发事件
         kEventWindowMove,           //Window类：发送给Focus控件，当窗口大小发生变化时触发事件
         kEventWindowCreate,         //Window类，当窗口创建完成时触发，wParam为1表示DoModal对话框，为0表示普通窗口

--- a/examples/cef/CefForm.cpp
+++ b/examples/cef/CefForm.cpp
@@ -47,11 +47,13 @@ void CefForm::OnInitWindow()
     m_pDevToolBtn = dynamic_cast<ui::Button*>(FindControl(_T("btn_dev_tool")));
     m_pEditUrl = dynamic_cast<ui::RichEdit*>(FindControl(_T("edit_url")));
     ASSERT(m_pDevToolBtn != nullptr);
-    ASSERT(m_pEditUrl != nullptr);
+    //ASSERT(m_pEditUrl != nullptr);
 
     // 设置输入框样式
-    m_pEditUrl->SetSelAllOnFocus(true);
-    m_pEditUrl->AttachReturn(UiBind(&CefForm::OnNavigate, this, std::placeholders::_1));
+    if (m_pEditUrl != nullptr) {
+        m_pEditUrl->SetSelAllOnFocus(true);
+        m_pEditUrl->AttachReturn(UiBind(&CefForm::OnNavigate, this, std::placeholders::_1));
+    }
 
     if (m_pCefControl != nullptr) {
         m_pCefControl->SetCefEventHandler(this);
@@ -81,6 +83,15 @@ void CefForm::OnInitWindow()
 
     //设置控制主进程单例的回调函数
     ui::CefManager::GetInstance()->SetAlreadyRunningAppRelaunch(UiBind(&CefForm::OnAlreadyRunningAppRelaunch, this, std::placeholders::_1));
+
+    if (!ui::CefManager::GetInstance()->IsEnableOffScreenRendering()) {
+        //处理控件多焦点问题（由于cef控件是子窗口模式，duilib内部无法自己完成这个功能）
+        AttachWindowKillFocus([this](const ui::EventArgs& args) {
+            //当窗口失去焦点的时候，让界面中的控件失去焦点，避免出现网页与界面控件同时处于焦点状态的问题
+            KillFocusControl();
+            return true;
+            });
+    }
 }
 
 void CefForm::OnPreCloseWindow()

--- a/examples/multi_browser/browser/BrowserBox.cpp
+++ b/examples/multi_browser/browser/BrowserBox.cpp
@@ -103,13 +103,6 @@ void BrowserBox::InitBrowserBox(const DString &url)
         }
     }
 #endif
-
-    // Box获取焦点时把焦点转移给Cef控件
-    this->AttachSetFocus([this](const ui::EventArgs& param)->bool
-    {
-        m_pCefControl->SetFocus();
-        return true;
-    }); 
 }
 
 void BrowserBox::UninitBrowserBox()
@@ -155,6 +148,21 @@ void BrowserBox::SetPos(UiRect rc)
         m_pTaskBarItem->InvalidateTab();
     }
 #endif
+}
+
+bool BrowserBox::OnSetFocus(const ui::EventArgs& msg)
+{
+    // Box获取焦点时把焦点转移给Cef控件
+    if (m_pCefControl) {
+        m_pCefControl->SetFocus();
+    }
+
+    //不再调用基类的方法，避免覆盖输入法管理的逻辑（基类会关闭输入法）
+    if (GetState() == kControlStateNormal) {
+        SetState(kControlStateHot);
+        Invalidate();
+    }
+    return true;
 }
 
 void BrowserBox::OnAfterCreated(CefRefPtr<CefBrowser> browser)

--- a/examples/multi_browser/browser/BrowserBox.h
+++ b/examples/multi_browser/browser/BrowserBox.h
@@ -79,6 +79,10 @@ public:
     TaskbarTabItem* GetTaskbarItem();
 #endif
 
+    /** 控件类型
+    */
+    virtual DString GetType() const override { return _T("BrowserBox"); }
+
     /**
     * 覆盖父类虚函数，用于指定本控件所属窗体
     * @param[in] pWindow 所属窗口指针
@@ -97,6 +101,11 @@ public:
     * @return void    无返回值
     */
     virtual void SetPos(ui::UiRect rc) override;
+
+protected:
+    /** 获取焦点
+    */
+    virtual bool OnSetFocus(const ui::EventArgs& msg) override;
 
 private:
 


### PR DESCRIPTION
焦点和输入法管理相关的机制调整：
1、CEF控件：CefBrowserHandler的实现中，去掉对CefFocusHandler接口的实现，上次提交的实现会导致页面中输入法的焦点出现异常。
2、cef示例程序的问题修复：界面的Edit控件与网页内的输入框会同时具有输入焦点，并且存在输入法不同步的问题。
3、输入法管理逻辑的优化：1、各控件之间，保持输入法同步；2、当控件不可输入时，禁用输入法（原来中文可以打字，但不能输入文字，体验不好）；3、当界面存在CEF控件子窗口时，保持网页的输入法与编辑框控件的输入法同步。
4、CEF控件：完善离屏渲染模式下的输入法管理机制：109版本的64位版本离屏渲染模式，输入法输入时，libcef.dll内部会崩溃，原因未知，现禁止输入法功能（副作用：中文输入法的候选框位置不正确）。

