### PR TITLE
RichEdit富文本模式下的兼容性问题修复，ListCtrl表头拖动问题修复

### DIFF
--- a/duilib/Control/Combo.cpp
+++ b/duilib/Control/Combo.cpp
@@ -677,6 +677,7 @@ bool Combo::SetItemText(size_t iIndex, const DString& itemText)
         ASSERT(pTreeNode != nullptr);
         if (pTreeNode != nullptr) {
             pTreeNode->SetText(itemText);
+            OnSelectedItemChanged();
             return true;
         }
     }
@@ -738,12 +739,16 @@ bool Combo::DeleteItem(size_t iIndex)
             }
         }
     }
+    if (bRemoved) {
+        OnSelectedItemChanged();
+    }
     return bRemoved;
 }
 
 void Combo::DeleteAllItems()
 {
     m_treeView.GetRootNode()->RemoveAllChildNodes();
+    OnSelectedItemChanged();
 }
 
 size_t Combo::SelectTextItem(const DString& itemText, bool bTriggerEvent)
@@ -763,8 +768,9 @@ size_t Combo::SelectTextItem(const DString& itemText, bool bTriggerEvent)
             }
         }
     }
-    if (Box::IsValidItemIndex(nSelIndex)) {
-        m_treeView.SelectItem(nSelIndex, false, bTriggerEvent);
+    m_treeView.SelectItem(nSelIndex, false, bTriggerEvent);
+    if (!bTriggerEvent) {
+        OnSelectedItemChanged();
     }
     return nSelIndex;
 }
@@ -990,7 +996,10 @@ void Combo::OnSelectedItemChanged()
         size_t nSelIndex = GetCurSel();
         if (Box::IsValidItemIndex(nSelIndex)) {
             m_pEditControl->SetText(GetItemText(nSelIndex));
-        }        
+        }
+        else {
+            m_pEditControl->SetText(DString());
+        }
     }
 }
 

--- a/duilib/Control/ListCtrlHeaderItem.cpp
+++ b/duilib/Control/ListCtrlHeaderItem.cpp
@@ -876,6 +876,10 @@ bool ListCtrlHeaderItem::AdjustItemOrders(const UiPoint& pt,
         else {
             //向右侧交换
             nMouseItemIndex += 1;
+            if (nMouseItemIndex >= itemCount) {
+                //已经到最后一列，将其放在最后
+                nMouseItemIndex = itemCount - 1;
+            }
             ASSERT(nMouseItemIndex < itemCount);
             if (nMouseItemIndex < itemCount) {
                 pHeader->SetItemIndex(this, nMouseItemIndex);

--- a/duilib/Core/NativeWindow_Windows.cpp
+++ b/duilib/Core/NativeWindow_Windows.cpp
@@ -2735,11 +2735,11 @@ void NativeWindow_Windows::EnableIME(HWND hwnd, bool bEnable)
             //检查输入法是否打开，给出断言
             HIMC hImc = ::ImmGetContext(hwnd);
             ASSERT(hImc != nullptr);
-            if (hImc != nullptr) {
-                ASSERT(::ImmGetOpenStatus(hImc));
+            if (hImc != nullptr) {                
                 if (!::ImmGetOpenStatus(hImc)) {
                     ::ImmSetOpenStatus(hImc, TRUE);
                 }
+                ASSERT(::ImmGetOpenStatus(hImc));
                 ::ImmReleaseContext(hwnd, hImc);
             }
         }

--- a/duilib/Core/UiFont.h
+++ b/duilib/Core/UiFont.h
@@ -21,11 +21,11 @@ public:
         m_bStrikeOut(false)
     {}
 
-    /** 字体名称
+    /** 字体名称（如果为空，表示不含有效字体名称）
     */
     UiString m_fontName;
 
-    /** 字体大小（单位：像素）
+    /** 字体大小（单位：像素），如果为0表示不含字体大小信息
     */
     int32_t m_fontSize;
 


### PR DESCRIPTION
RichEdit富文本模式下的兼容性问题修复：当出现混合字体的情况下，会异常 报错 #82。
ListCtrl表头拖动问题修复：当拖动的目标在最后一列的右侧时，程序会报错（异常 报错 #82）
