### PR TITLE
Add MacOS platform support of nim_duilib libraries and Adapt some examples for MacOS platform

### DIFF
--- a/bin/resources/themes/default/global.xml
+++ b/bin/resources/themes/default/global.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Global>
     <!--默认字体名称，列表形式，依次匹配，直到发现第一个有效字体作为默认字体名称，多个字体名称用逗号分隔-->
-    <DefaultFontFamilyNames value="微软雅黑,宋体"/>
+    <DefaultFontFamilyNames value="微软雅黑,宋体,PingFang SC"/>
     
     <!--所有字体：默认为五号字-->
     <Font id="system_12" name="system" size="12"/>

--- a/duilib/Box/ListBox.cpp
+++ b/duilib/Box/ListBox.cpp
@@ -1413,6 +1413,8 @@ bool ListBox::SortItems(PFNCompareFunc pfnCompare, void* pCompareContext)
     m_pCompareContext = pCompareContext;
 #ifdef _MSC_VER
     qsort_s(&(*m_items.begin()), m_items.size(), sizeof(Control*), ListBox::ItemComareFuncWindows, this);
+#elif defined(__APPLE__) // macOS
+    qsort_r(&(*m_items.begin()), m_items.size(), sizeof(Control*), this, ListBox::ItemComareFuncMacOS);   
 #else
     qsort_r(&(*m_items.begin()), m_items.size(), sizeof(Control*), ListBox::ItemComareFuncLinux, this);
 #endif    

--- a/duilib/Box/ListBox.cpp
+++ b/duilib/Box/ListBox.cpp
@@ -1452,6 +1452,15 @@ int ListBox::ItemComareFuncLinux(const void *item1, const void *item2, void* pvl
     return pThis->ItemComareFunc(item1, item2);
 }
 
+int ListBox::ItemComareFuncMacOS(void* context, const void* item1, const void* item2)
+{
+    ListBox* pThis = (ListBox*)context;
+    if (!pThis || !item1 || !item2) {
+        return 0;
+    }
+    return pThis->ItemComareFunc(item1, item2);
+}
+
 int ListBox::ItemComareFunc(const void *item1, const void *item2)
 {
     if (!item1 || !item2) {

--- a/duilib/Box/ListBox.h
+++ b/duilib/Box/ListBox.h
@@ -300,6 +300,8 @@ protected:
      */
     static int ItemComareFuncWindows(void* pvlocale, const void* item1, const void* item2);
     static int ItemComareFuncLinux(const void* item1, const void* item2, void* pvlocale);
+    static int ItemComareFuncMacOS(void* context, const void* item1, const void* item2);
+
     int ItemComareFunc(const void* item1, const void* item2);
 
     /** 选择子项(单选)

--- a/duilib/CMakeLists.txt
+++ b/duilib/CMakeLists.txt
@@ -23,9 +23,20 @@ endif()
 
 add_definitions(-DSK_GANESH -DSK_GL -DSK_RELEASE)
 
+#设置libcef目录路径
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")  # macOS
+    set(CEF_LIB_DIR "libcef_macos")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")  # Linux
+    set(CEF_LIB_DIR "libcef_linux")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")  # Windows
+    set(CEF_LIB_DIR "libcef_windows")
+else()
+    message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_NAME}")
+endif()
+
 #设置include目录
 get_filename_component(DUILIB_SRC_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../" ABSOLUTE)
-get_filename_component(CEF_INCLUDE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/third_party/libcef_linux/" ABSOLUTE)
+get_filename_component(CEF_INCLUDE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/third_party/${CEF_LIB_DIR}/" ABSOLUTE)
 get_filename_component(SKIA_SRC_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../skia/" ABSOLUTE)
 get_filename_component(SDL_SRC_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/../../SDL3/" ABSOLUTE)
 
@@ -102,3 +113,19 @@ add_library(duilib
     	    ${SKIA_HDRS}
     	    ${SKIA_SRCS}
            )
+
+# macOS 特有链接库
+if(APPLE)
+    find_package(Freetype REQUIRED)
+    find_library(CORETEXT_LIBRARY CoreText)
+    target_link_libraries(duilib
+        PRIVATE
+        Freetype::Freetype
+        ${CORETEXT_LIBRARY}
+        "-framework Cocoa"
+        "-framework OpenGL"
+        "-framework IOKit"
+        "-framework CoreFoundation"
+        "-framework CoreGraphics"
+    )
+endif()

--- a/duilib/Control/ColorPickerRegular.cpp
+++ b/duilib/Control/ColorPickerRegular.cpp
@@ -87,7 +87,7 @@ private:
         bool m_bSelected = false;
 
         //比较函数
-        bool operator < (const RegularColor& r)
+        bool operator < (const RegularColor& r) const
         {
             //按照颜色的灰度值排序
             double v1 = colorValue.GetR() * 0.299 + colorValue.GetG() * 0.587 + colorValue.GetB() * 0.114;

--- a/duilib/RenderSkia/FontMgr_Skia.cpp
+++ b/duilib/RenderSkia/FontMgr_Skia.cpp
@@ -9,8 +9,14 @@
 #include "include/core/SkFont.h"
 #include "include/core/SkData.h"
 
+#include "include/core/SkRefCnt.h"  // 包含sk_sp的完整定义
+#include "include/ports/SkFontMgr_mac_ct.h"  // macOS专用API
+#include "include/core/SkTypeface.h" // 确保SkFontMgr完整定义
+
 #if defined(SK_BUILD_FOR_WIN)
     #include "include/ports/SkTypeface_win.h"
+#elif defined(SK_BUILD_FOR_MAC)
+    #include "include/ports/SkTypeface_mac.h"
 #else
     #include "include/ports/SkFontMgr_fontconfig.h"
 #endif
@@ -188,6 +194,10 @@ FontMgr_Skia::FontMgr_Skia()
 #if defined(SK_BUILD_FOR_WIN)
     //Windows系统
     m_impl->m_pSkFontMgr = SkFontMgr_New_DirectWrite();
+#elif defined(SK_BUILD_FOR_MAC) 
+    // macOS/iOS系统
+    m_impl->m_pSkFontMgr = SkFontMgr_New_CoreText(nullptr);  // 使用nullptr表示系统默认字体集
+
 #else
     //Linux系统
     m_impl->m_pSkFontMgr = SkFontMgr_New_FontConfig(nullptr);

--- a/duilib/Utils/ProcessSingleton.cpp
+++ b/duilib/Utils/ProcessSingleton.cpp
@@ -4,6 +4,8 @@
     #include "ProcessSingleton_Windows.h"
 #elif defined (DUILIB_BUILD_FOR_LINUX)
     #include "ProcessSingleton_Linux.h"
+#elif defined (DUILIB_BUILD_FOR_MACOS)
+    #include "ProcessSingleton_MacOS.h"
 #endif
 
 #include "duilib/Utils/StringConvert.h"

--- a/duilib/Utils/ProcessSingleton_MacOS.h
+++ b/duilib/Utils/ProcessSingleton_MacOS.h
@@ -1,0 +1,246 @@
+#ifndef UI_UTILS_PROCESS_SINGLETON_MACOS_H_
+#define UI_UTILS_PROCESS_SINGLETON_MACOS_H_
+
+#include "ProcessSingletonData.h"
+
+#ifdef DUILIB_BUILD_FOR_MACOS
+
+#include <sys/file.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <libproc.h>  // macOS 特有的进程相关头文件
+
+namespace ui
+{
+/** 跨进程单例的实现（macOS实现）
+*/
+class UILIB_API ProcessSingletonImpl: public ProcessSingleton
+{
+public:
+    explicit ProcessSingletonImpl(const std::string& strAppName) :
+        ProcessSingleton(strAppName)
+    {
+        InitializePlatformComponents();
+    }
+
+    virtual ~ProcessSingletonImpl() override
+    {
+        m_bRunning = false;
+        CleanupPlatformComponents();
+    }
+
+protected:
+    ProcessSingletonImpl(const ProcessSingleton&) = delete;
+    ProcessSingletonImpl& operator=(const ProcessSingletonImpl&) = delete;
+
+public:
+    virtual void InitializePlatformComponents() override final
+    {
+        try {
+            std::string strRuntimeDir = GetUserRuntimePath();
+            CreateDirectoryRecursive(strRuntimeDir);
+
+            // macOS 需要更严格的临时文件路径
+            std::string strLockFile = strRuntimeDir + "/" + m_strAppName + ".lock";
+            
+            // macOS 需要先 unlink 已存在的文件
+            ::unlink(strLockFile.c_str());
+            
+            m_nLockFile = ::open(strLockFile.c_str(), O_RDWR | O_CREAT, 0600);
+            if (m_nLockFile == -1) {
+                throw std::system_error(errno, std::system_category(), "Open lock file failed");
+            }
+
+            // macOS 推荐使用 fcntl 而非 flock
+            struct flock fl;
+            fl.l_start = 0;
+            fl.l_len = 0;
+            fl.l_pid = getpid();
+            fl.l_type = F_WRLCK;
+            fl.l_whence = SEEK_SET;
+            
+            if (::fcntl(m_nLockFile, F_SETLK, &fl) == -1) {
+                if (errno == EAGAIN || errno == EACCES) {
+                    return;  // 已存在实例
+                }
+                throw std::system_error(errno, std::system_category(), "File lock failed");
+            }
+
+            // macOS 需要显式设置文件权限
+            ::fchmod(m_nLockFile, 0600);
+        }
+        catch (const std::exception& ex) {
+            CleanupPlatformComponents();
+            throw;
+        }
+    }
+
+    virtual bool PlatformCheckInstance() override final
+    {
+        return errno == EAGAIN || errno == EACCES;
+    }
+
+    virtual bool PlatformSendData(const std::string& strData) override final
+    {
+        try {
+            int nSocket = ::socket(AF_UNIX, SOCK_STREAM, 0);
+            if (nSocket == -1) {
+                throw std::system_error(errno, std::system_category(), "Socket creation failed");
+            }
+
+            sockaddr_un addr = { 0 };
+            addr.sun_family = AF_UNIX;
+            
+            // macOS 对 socket 路径长度限制更严格
+            std::string strSocketPath = GetUserRuntimePath() + "/" + m_strAppName + ".sock";
+            if (strSocketPath.size() > sizeof(addr.sun_path) - 1) {
+                strSocketPath = "/tmp/" + m_strAppName + ".sock";  // 回退到/tmp
+            }
+            
+            ::strlcpy(addr.sun_path, strSocketPath.c_str(), sizeof(addr.sun_path));
+
+            if (::connect(nSocket, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+                ::close(nSocket);
+                return false;
+            }
+
+            ssize_t nSent = ::write(nSocket, strData.data(), strData.size());
+            ::close(nSocket);
+            return nSent == static_cast<ssize_t>(strData.size());
+        }
+        catch (const std::exception& ex) {
+            LogError("macOS send error: " + std::string(ex.what()));
+            return false;
+        }
+    }
+
+    virtual void PlatformListen() override final
+    {
+        try {
+            m_nSocket = ::socket(AF_UNIX, SOCK_STREAM, 0);
+            if (m_nSocket == -1) {
+                throw std::system_error(errno, std::system_category(), "Socket creation failed");
+            }
+
+            sockaddr_un addr = { 0 };
+            addr.sun_family = AF_UNIX;
+            
+            // 处理 macOS 的 socket 路径长度限制
+            std::string strSocketPath = GetUserRuntimePath() + "/" + m_strAppName + ".sock";
+            if (strSocketPath.size() > sizeof(addr.sun_path) - 1) {
+                strSocketPath = "/tmp/" + m_strAppName + ".sock";
+            }
+            
+            ::strlcpy(addr.sun_path, strSocketPath.c_str(), sizeof(addr.sun_path));
+
+            // macOS 需要先 unlink 已存在的 socket
+            ::unlink(strSocketPath.c_str());
+            
+            if (::bind(m_nSocket, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+                ::close(m_nSocket);
+                throw std::system_error(errno, std::system_category(), "Socket bind failed");
+            }
+
+            // macOS 需要显式设置权限
+            ::fchmod(m_nSocket, 0600);
+            
+            if (::listen(m_nSocket, 5) == -1) {
+                ::close(m_nSocket);
+                throw std::system_error(errno, std::system_category(), "Socket listen failed");
+            }
+
+            while (m_bRunning) {
+                int nClient = ::accept(m_nSocket, nullptr, nullptr);
+                if (nClient == -1) continue;
+
+                char pBuffer[ProcessSingletonData::MAX_DATA_SIZE + sizeof(ProcessSingletonData::ProtocolHeader)] = { 0 };
+                ssize_t nRead = ::recv(nClient, pBuffer, sizeof(pBuffer), 0);  // macOS 不需要 MSG_NOSIGNAL
+                if (nRead > 0) {
+                    try {
+                        auto vecArgs = ProcessSingletonData::DeserializeData(std::string(pBuffer, nRead));
+                        OnAlreadyRunningAppRelaunch(vecArgs);
+                    }
+                    catch (const std::exception& ex) {
+                        LogError("Invalid data received: " + std::string(ex.what()));
+                    }
+                }
+                ::close(nClient);
+            }
+
+            ::close(m_nSocket);
+            ::unlink(strSocketPath.c_str());
+        }
+        catch (const std::exception& ex) {
+            LogError("macOS listener error: " + std::string(ex.what()));
+        }
+    }
+    
+    virtual void CleanupPlatformComponents() override final
+    {
+        if (m_nLockFile != -1) {
+            // macOS 使用 fcntl 解锁
+            struct flock fl;
+            fl.l_start = 0;
+            fl.l_len = 0;
+            fl.l_pid = getpid();
+            fl.l_type = F_UNLCK;
+            fl.l_whence = SEEK_SET;
+            ::fcntl(m_nLockFile, F_SETLK, &fl);
+            
+            ::close(m_nLockFile);
+            m_nLockFile = -1;
+        }
+        if (m_nSocket != -1) {
+            ::close(m_nSocket);
+            m_nSocket = -1;
+        }
+        if (m_thListener.joinable()) {
+            m_thListener.join();
+        }
+    }
+
+private:
+    std::string GetUserRuntimePath() 
+    {
+        // macOS 优先使用 $TMPDIR
+        const char* pszTmpDir = ::getenv("TMPDIR");
+        if (pszTmpDir && *pszTmpDir) {
+            return std::string(pszTmpDir) + ".cppapp_" + m_strAppName;
+        }
+
+        // 其次是 $HOME/Library/Caches
+        struct passwd* pwd = ::getpwuid(getuid());
+        if (pwd && pwd->pw_dir) {
+            return std::string(pwd->pw_dir) + "/Library/Caches/.cppapp_" + m_strAppName;
+        }
+
+        // 最后回退到 /tmp
+        return "/tmp/.cppapp_" + m_strAppName + "_" + std::to_string(getuid());
+    }
+    
+    static void CreateDirectoryRecursive(const std::string& strPath)
+    {
+        std::string::size_type nPos = 0;
+        do {
+            nPos = strPath.find('/', nPos + 1);
+            std::string strSubDir = strPath.substr(0, nPos);
+            if (::mkdir(strSubDir.c_str(), 0700) == -1 && errno != EEXIST) {
+                throw std::system_error(errno, std::system_category(), "Create directory failed");
+            }
+        } while (nPos != std::string::npos);
+    }
+    
+private:
+    // macOS 实现
+    int m_nLockFile = -1;
+    int m_nSocket = -1;
+};
+
+} // namespace ui
+
+#endif // DUILIB_BUILD_FOR_MACOS
+#endif // UI_UTILS_PROCESS_SINGLETON_MACOS_H_

--- a/examples/ColorPicker/CMakeLists.txt
+++ b/examples/ColorPicker/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()

--- a/examples/ColorPicker/main_macos.cpp
+++ b/examples/ColorPicker/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/DpiAware/CMakeLists.txt
+++ b/examples/DpiAware/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/DpiAware/main_macos.cpp
+++ b/examples/DpiAware/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()

--- a/examples/basic/main_macos.cpp
+++ b/examples/basic/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/controls/CMakeLists.txt
+++ b/examples/controls/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,30 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()

--- a/examples/controls/main_macos.cpp
+++ b/examples/controls/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -48,35 +48,33 @@ make
 cp "$SRC_ROOT_DIR/build_temp/libcef_dll_wrapper/libcef_dll_wrapper/libcef_dll_wrapper.a" "$SRC_ROOT_DIR/libs/libcef_dll_wrapper.a"
 cd "$SRC_ROOT_DIR/"
 
-# #编译duilib
+# # #编译duilib
 rm -f "$SRC_ROOT_DIR/libs/libduilib.a"
 cmake -S "$SRC_ROOT_DIR/duilib/" -B "$SRC_ROOT_DIR/build_temp/duilib" -DCMAKE_BUILD_TYPE=Debug
 cd "$SRC_ROOT_DIR/build_temp/duilib"
 make -j 4
 cd "$SRC_ROOT_DIR/"
 
-
-
 # 编译examples下的各个程序
-# cmake -S "$SRC_ROOT_DIR/examples/basic/" -B "$SRC_ROOT_DIR/build_temp/basic" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/basic"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/basic/" -B "$SRC_ROOT_DIR/build_temp/basic" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/basic"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/ColorPicker/" -B "$SRC_ROOT_DIR/build_temp/ColorPicker" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/ColorPicker"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/ColorPicker/" -B "$SRC_ROOT_DIR/build_temp/ColorPicker" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/ColorPicker"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/controls/" -B "$SRC_ROOT_DIR/build_temp/controls" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/controls"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/controls/" -B "$SRC_ROOT_DIR/build_temp/controls" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/controls"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/DpiAware/" -B "$SRC_ROOT_DIR/build_temp/DpiAware" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/DpiAware"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/DpiAware/" -B "$SRC_ROOT_DIR/build_temp/DpiAware" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/DpiAware"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
 # cmake -S "$SRC_ROOT_DIR/examples/layouts/" -B "$SRC_ROOT_DIR/build_temp/layouts" -DCMAKE_BUILD_TYPE=Debug
 # cd "$SRC_ROOT_DIR/build_temp/layouts"

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -35,11 +35,7 @@ cd "$SRC_ROOT_DIR/"
 
 #编译libwebp
 rm -f "$SRC_ROOT_DIR/libs/libduilib-webp.a"
-cmake -S "$SRC_ROOT_DIR/duilib/third_party/libwebp/" -B "$SRC_ROOT_DIR/build_temp/libwebp" \
--DWEBP_ENABLE_SIMD=ON \
--DWEBP_NEAR_LOSSLESS=OFF \
--DCMAKE_OSX_ARCHITECTURES="arm64" \
--DCMAKE_SYSTEM_PROCESSOR="arm64"
+cmake -S "$SRC_ROOT_DIR/duilib/third_party/libwebp/" -B "$SRC_ROOT_DIR/build_temp/libwebp" 
 cd "$SRC_ROOT_DIR/build_temp/libwebp"
 make 
 cd "$SRC_ROOT_DIR/"
@@ -52,12 +48,12 @@ make
 cp "$SRC_ROOT_DIR/build_temp/libcef_dll_wrapper/libcef_dll_wrapper/libcef_dll_wrapper.a" "$SRC_ROOT_DIR/libs/libcef_dll_wrapper.a"
 cd "$SRC_ROOT_DIR/"
 
-# # #编译duilib
-# rm -f "$SRC_ROOT_DIR/libs/libduilib.a"
-# cmake -S "$SRC_ROOT_DIR/duilib/" -B "$SRC_ROOT_DIR/build_temp/duilib" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/duilib"
-# make -j 4
-# cd "$SRC_ROOT_DIR/"
+# #编译duilib
+rm -f "$SRC_ROOT_DIR/libs/libduilib.a"
+cmake -S "$SRC_ROOT_DIR/duilib/" -B "$SRC_ROOT_DIR/build_temp/duilib" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/duilib"
+make -j 4
+cd "$SRC_ROOT_DIR/"
 
 
 


### PR DESCRIPTION
Add MacOS platform support of nim_duilib libraries.
Adapt some examples like basic, ColorPicker, controls and DpiAware for MacOS platform and these examples can now work on MacOS platform.
Add PingFang SC in DefaultFontFamilyNames in resources/themes/default/global.xml for MacOS platform.

#92  The work to add MacOS platform support of nim_duilib libraries is partly down except some examples. 

Thanks for your valuable time and great efforts.