### PR TITLE
Adapt some examples for MacOS platform

### DIFF
--- a/examples/ListBox/CMakeLists.txt
+++ b/examples/ListBox/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/ListBox/main_macos.cpp
+++ b/examples/ListBox/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/ListCtrl/CMakeLists.txt
+++ b/examples/ListCtrl/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/ListCtrl/main_macos.cpp
+++ b/examples/ListCtrl/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/MoveControl/CMakeLists.txt
+++ b/examples/MoveControl/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/MoveControl/main_macos.cpp
+++ b/examples/MoveControl/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/MultiLang/CMakeLists.txt
+++ b/examples/MultiLang/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/MultiLang/main_macos.cpp
+++ b/examples/MultiLang/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/RichEdit/CMakeLists.txt
+++ b/examples/RichEdit/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/RichEdit/main_macos.cpp
+++ b/examples/RichEdit/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/VirtualListBox/CMakeLists.txt
+++ b/examples/VirtualListBox/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/VirtualListBox/main_macos.cpp
+++ b/examples/VirtualListBox/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/layouts/CMakeLists.txt
+++ b/examples/layouts/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/layouts/main_macos.cpp
+++ b/examples/layouts/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/render/CMakeLists.txt
+++ b/examples/render/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/render/main_macos.cpp
+++ b/examples/render/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/examples/threads/CMakeLists.txt
+++ b/examples/threads/CMakeLists.txt
@@ -31,7 +31,11 @@ aux_source_directory(${CMAKE_CURRENT_LIST_DIR} SRC_FILES)
 
 include_directories(${DUILIB_SRC_ROOT_DIR})
 link_directories("${DUILIB_SRC_ROOT_DIR}/libs/")
-link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.arm64.Release/")
+elseif(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    link_directories("${SKIA_SRC_ROOT_DIR}/out/LLVM.x64.Release/")
+endif()
 link_directories("${SDL_SRC_ROOT_DIR}/lib64/")
 link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 
@@ -39,4 +43,31 @@ link_directories("${SDL_SRC_ROOT_DIR}/lib/")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${DUILIB_SRC_ROOT_DIR}/bin/")
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})
-target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+if(UNIX AND NOT APPLE)
+    target_link_libraries(${PROJECT_NAME} duilib SDL3 skia duilib-cximage duilib-webp duilib-png duilib-zlib freetype fontconfig pthread dl)
+endif()
+
+# macOS 特殊配置
+if(APPLE)
+    # 查找必需框架
+    find_library(ACCELERATE Accelerate)
+    find_library(COREFOUNDATION CoreFoundation)
+    find_library(CORETEXT CoreText)
+    find_library(COREGRAPHICS CoreGraphics)
+    # 字体配置
+    find_package(Fontconfig REQUIRED)
+    find_package(Freetype REQUIRED)
+endif()
+
+if(APPLE)
+    # 链接库（注意顺序！）
+  target_link_libraries(${PROJECT_NAME}
+  # 第三方库（按依赖顺序）
+  duilib duilib-cximage duilib-webp duilib-png duilib-zlib SDL3 skia Freetype::Freetype Fontconfig::Fontconfig
+  # 系统库
+  ${ACCELERATE} ${COREFOUNDATION} ${CORETEXT} ${COREGRAPHICS} pthread dl
+  # 显式框架声明（必须放在最后）
+  "-framework AppKit" "-framework Foundation" "-framework Metal"
+  )
+endif()
+

--- a/examples/threads/main_macos.cpp
+++ b/examples/threads/main_macos.cpp
@@ -1,0 +1,22 @@
+#if defined(__APPLE__) || defined(macintosh) || defined(Macintosh)
+#include <TargetConditionals.h>  // macOS 平台检测头文件
+#if TARGET_OS_MAC               // 明确排除iOS等其他Apple平台
+
+#include "duilib/duilib_config_macos.h"  // macOS专用配置头文件
+#include "TestApplication.h"
+#include <CoreFoundation/CoreFoundation.h>  // macOS核心服务头文件
+
+// 定义macOS应用程序入口点
+int main(int argc, char** argv) {
+    // macOS特有的初始化（例如：激活多线程GCD）
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, false);
+    
+    // 创建并运行应用
+    TestApplication app;
+    app.Run();
+    
+    return 0;
+}
+
+#endif // TARGET_OS_MAC
+#endif // __APPLE__ || macintosh || Macintosh

--- a/macos_build.sh
+++ b/macos_build.sh
@@ -44,7 +44,7 @@ cd "$SRC_ROOT_DIR/"
 rm -f "$SRC_ROOT_DIR/libs/libcef_dll_wrapper.a"
 cmake -S "$SRC_ROOT_DIR/duilib/third_party/libcef_macos/" -B "$SRC_ROOT_DIR/build_temp/libcef_dll_wrapper" -DCMAKE_BUILD_TYPE=Debug
 cd "$SRC_ROOT_DIR/build_temp/libcef_dll_wrapper"
-make 
+make -j 6
 cp "$SRC_ROOT_DIR/build_temp/libcef_dll_wrapper/libcef_dll_wrapper/libcef_dll_wrapper.a" "$SRC_ROOT_DIR/libs/libcef_dll_wrapper.a"
 cd "$SRC_ROOT_DIR/"
 
@@ -52,7 +52,7 @@ cd "$SRC_ROOT_DIR/"
 rm -f "$SRC_ROOT_DIR/libs/libduilib.a"
 cmake -S "$SRC_ROOT_DIR/duilib/" -B "$SRC_ROOT_DIR/build_temp/duilib" -DCMAKE_BUILD_TYPE=Debug
 cd "$SRC_ROOT_DIR/build_temp/duilib"
-make -j 4
+make -j 6
 cd "$SRC_ROOT_DIR/"
 
 # 编译examples下的各个程序
@@ -76,45 +76,50 @@ cd "$SRC_ROOT_DIR/build_temp/DpiAware"
 make clean; make
 cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/layouts/" -B "$SRC_ROOT_DIR/build_temp/layouts" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/layouts"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/layouts/" -B "$SRC_ROOT_DIR/build_temp/layouts" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/layouts"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/ListBox/" -B "$SRC_ROOT_DIR/build_temp/ListBox" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/ListBox"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/ListBox/" -B "$SRC_ROOT_DIR/build_temp/ListBox" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/ListBox"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/ListCtrl/" -B "$SRC_ROOT_DIR/build_temp/ListCtrl" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/ListCtrl"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/ListCtrl/" -B "$SRC_ROOT_DIR/build_temp/ListCtrl" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/ListCtrl"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/move_control/" -B "$SRC_ROOT_DIR/build_temp/move_control" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/move_control"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/MoveControl/" -B "$SRC_ROOT_DIR/build_temp/MoveControl" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/MoveControl"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/MultiLang/" -B "$SRC_ROOT_DIR/build_temp/MultiLang" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/MultiLang"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/MultiLang/" -B "$SRC_ROOT_DIR/build_temp/MultiLang" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/MultiLang"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/render/" -B "$SRC_ROOT_DIR/build_temp/render" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/render"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/render/" -B "$SRC_ROOT_DIR/build_temp/render" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/render"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/RichEdit/" -B "$SRC_ROOT_DIR/build_temp/RichEdit" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/RichEdit"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/RichEdit/" -B "$SRC_ROOT_DIR/build_temp/RichEdit" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/RichEdit"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
-# cmake -S "$SRC_ROOT_DIR/examples/VirtualListBox/" -B "$SRC_ROOT_DIR/build_temp/VirtualListBox" -DCMAKE_BUILD_TYPE=Debug
-# cd "$SRC_ROOT_DIR/build_temp/VirtualListBox"
-# make clean; make
-# cd "$SRC_ROOT_DIR/"
+cmake -S "$SRC_ROOT_DIR/examples/VirtualListBox/" -B "$SRC_ROOT_DIR/build_temp/VirtualListBox" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/VirtualListBox"
+make clean; make
+cd "$SRC_ROOT_DIR/"
+
+cmake -S "$SRC_ROOT_DIR/examples/threads/" -B "$SRC_ROOT_DIR/build_temp/threads" -DCMAKE_BUILD_TYPE=Debug
+cd "$SRC_ROOT_DIR/build_temp/threads"
+make clean; make
+cd "$SRC_ROOT_DIR/"
 
 # cmake -S "$SRC_ROOT_DIR/examples/cef/" -B "$SRC_ROOT_DIR/build_temp/cef" -DCMAKE_BUILD_TYPE=Debug
 # cd "$SRC_ROOT_DIR/build_temp/cef"


### PR DESCRIPTION
Adapt some examples for MacOS platform: layouts, ListBox, ListCtrl, MoveControl, MultiLang, render, RichEdit, VirtualListBox and threads, and they can now work on MacOS platform.