### PR TITLE
Control的Float设置为True后，父Control Resize的时候，导致Control大小和位置被重置 #135

### DIFF
--- a/duilib/Box/Layout.cpp
+++ b/duilib/Box/Layout.cpp
@@ -91,8 +91,14 @@ UiSize64 Layout::SetFloatPos(Control* pControl, const UiRect& rcContainer)
     }
 
     UiRect childPos = GetFloatPos(pControl, rcContainer, childSize);
+    if (pControl->IsFloat() && pControl->GetParent() != nullptr) {
+        //浮动控件：如果外部调整了其位置，则保持原位置
+        UiSize relativePos = pControl->GetRelativePos();
+        if (!relativePos.IsEmpty()) {
+            childPos.Offset(relativePos.cx, relativePos.cy);
+        }
+    }
     pControl->SetPos(childPos);
-    //TODO: 64位兼容性检查
     return UiSize64(childPos.Width(), childPos.Height());
 }
 

--- a/duilib/Core/Box.cpp
+++ b/duilib/Core/Box.cpp
@@ -100,7 +100,7 @@ void Box::SetPos(UiRect rc)
     Control::SetPos(rc);
     if (m_pLayout != nullptr) {
         m_pLayout->ArrangeChild(m_items, rc);    
-    }    
+    }
 }
 
 UiRect Box::GetPosWithoutPadding() const

--- a/duilib/Core/PlaceHolder.cpp
+++ b/duilib/Core/PlaceHolder.cpp
@@ -535,7 +535,32 @@ void PlaceHolder::SetRect(const UiRect& rc)
         //区域变化，标注绘制缓存脏标记位
         SetCacheDirty(true);
     }
-    m_uiRect = rc;    
+    m_uiRect = rc;
+    if ((GetParent() != nullptr) && IsFloat()) {
+        //浮动控件，则需要记录和父控件相对位置和大小
+        UiRect rcParent = GetParent()->GetRect();
+        UiPadding rcPadding = GetParent()->GetPadding();
+        UiMargin rcMargin = GetMargin();
+        m_uiRelativePos.cx = rc.left - rcParent.left;
+        m_uiRelativePos.cy = rc.top - rcParent.top;
+
+        m_uiRelativePos.cx -= (rcPadding.left + rcPadding.right);
+        m_uiRelativePos.cx -= (rcMargin.left + rcMargin.right);
+
+        m_uiRelativePos.cy -= (rcPadding.top + rcPadding.bottom);
+        m_uiRelativePos.cy -= (rcMargin.top + rcMargin.bottom);
+    }
+    else {
+        m_uiRelativePos.Clear();
+    }
+}
+
+UiSize PlaceHolder::GetRelativePos() const
+{
+    if (IsFloat()) {
+        return m_uiRelativePos;
+    }
+    return UiSize();
 }
 
 void PlaceHolder::Invalidate()

--- a/duilib/Core/PlaceHolder.h
+++ b/duilib/Core/PlaceHolder.h
@@ -128,6 +128,10 @@ public:
      */
     void SetFloat(bool bFloat);
 
+    /** 获取与父控件的相对位置(仅当控件为浮动控件时有效)
+    */
+    UiSize GetRelativePos() const;
+
 public:
     /** 获取控件设置的宽度和高度，宽高均包含内边距，但均不包含外边距
     */
@@ -400,6 +404,9 @@ private:
 
     //控件位置与大小
     UiRect m_uiRect;
+
+    //获取与父控件的相对位置(仅当控件为浮动控件时有效)
+    UiSize m_uiRelativePos;
 
     //外部设置的控件大小
     UiFixedSize m_cxyFixed;


### PR DESCRIPTION
Control的Float设置为True后，父Control Resize的时候，导致Control大小和位置被重置 #135