### PR TITLE
Control的Float设置为True后，父Control Resize的时候，导致Control大小和位置被重置 (#135)

### DIFF
--- a/docs/Control.md
+++ b/docs/Control.md
@@ -24,6 +24,7 @@
 | halign | left | string | SetHorAlignType|控件的横向位置,如(center),支持left、center、right三种位置 |
 | valign | top | string | SetVerAlignType|控件的纵向位置,如(center),支持top、center、bottom三种位置 |
 | float | false | bool | SetFloat|是否使用绝对定位,如“true”|
+| keep_float_pos | false | bool | SetKeepFloatPos|设置当父控件位置和大小调整时，是否保持浮动控件相对父控件的位置不变,如“true”|
 | bkcolor |  | string | SetBkColor|背景颜色字符串常量,如(white) |
 | bkcolor2 |  | string | SetBkColor2|第二背景颜色字符串常量,如果设置了第二背景色，则支持背景颜色渐变,如(blue) |
 | bkcolor2_direction | "1" | string | SetBkColor2Direction|第二背景色方向，"1": 左->右，"2": 上->下，"3": 左上->右下，"4": 右上->左下|

--- a/duilib/Box/Layout.cpp
+++ b/duilib/Box/Layout.cpp
@@ -91,12 +91,16 @@ UiSize64 Layout::SetFloatPos(Control* pControl, const UiRect& rcContainer)
     }
 
     UiRect childPos = GetFloatPos(pControl, rcContainer, childSize);
-    if (pControl->IsFloat() && pControl->GetParent() != nullptr) {
+    if (pControl->IsFloat() && pControl->IsKeepFloatPos() && (pControl->GetParent() != nullptr)) {
         //浮动控件：如果外部调整了其位置，则保持原位置
-        UiSize relativePos = pControl->GetRelativePos();
-        if (!relativePos.IsEmpty()) {
-            childPos.Offset(relativePos.cx, relativePos.cy);
-        }
+        UiSize oldFloatPos = pControl->GetFloatPos();
+        if ((oldFloatPos.cx != INT32_MIN) && (oldFloatPos.cy != INT32_MIN)) {
+            UiRect rcParent = pControl->GetParent()->GetRect();
+            UiSize newFloatPos;
+            newFloatPos.cx = childPos.left - rcParent.left;
+            newFloatPos.cy = childPos.top - rcParent.top;
+            childPos.Offset(oldFloatPos.cx - newFloatPos.cx, oldFloatPos.cy - newFloatPos.cy);
+        }        
     }
     pControl->SetPos(childPos);
     return UiSize64(childPos.Width(), childPos.Height());

--- a/duilib/Box/Layout.cpp
+++ b/duilib/Box/Layout.cpp
@@ -91,8 +91,14 @@ UiSize64 Layout::SetFloatPos(Control* pControl, const UiRect& rcContainer)
     }
 
     UiRect childPos = GetFloatPos(pControl, rcContainer, childSize);
+    if (pControl->IsFloat() && pControl->GetParent() != nullptr) {
+        //浮动控件：如果外部调整了其位置，则保持原位置
+        UiSize relativePos = pControl->GetRelativePos();
+        if (!relativePos.IsEmpty()) {
+            childPos.Offset(relativePos.cx, relativePos.cy);
+        }
+    }
     pControl->SetPos(childPos);
-    //TODO: 64位兼容性检查
     return UiSize64(childPos.Width(), childPos.Height());
 }
 

--- a/duilib/Core/Box.cpp
+++ b/duilib/Core/Box.cpp
@@ -100,7 +100,7 @@ void Box::SetPos(UiRect rc)
     Control::SetPos(rc);
     if (m_pLayout != nullptr) {
         m_pLayout->ArrangeChild(m_items, rc);    
-    }    
+    }
 }
 
 UiRect Box::GetPosWithoutPadding() const

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -368,6 +368,9 @@ void Control::SetAttribute(const DString& strName, const DString& strValue)
     else if (strName == _T("float")) {
         SetFloat(strValue == _T("true"));
     }
+    else if (strName == _T("keep_float_pos")) {
+        SetKeepFloatPos(strValue == _T("true"));
+    }
     else if (strName == _T("cache")) {
         SetUseCache(strValue == _T("true"));
     }

--- a/duilib/Core/PlaceHolder.cpp
+++ b/duilib/Core/PlaceHolder.cpp
@@ -535,7 +535,32 @@ void PlaceHolder::SetRect(const UiRect& rc)
         //区域变化，标注绘制缓存脏标记位
         SetCacheDirty(true);
     }
-    m_uiRect = rc;    
+    m_uiRect = rc;
+    if ((GetParent() != nullptr) && IsFloat()) {
+        //浮动控件，则需要记录和父控件相对位置和大小
+        UiRect rcParent = GetParent()->GetRect();
+        UiPadding rcPadding = GetParent()->GetPadding();
+        UiMargin rcMargin = GetMargin();
+        m_uiRelativePos.cx = rc.left - rcParent.left;
+        m_uiRelativePos.cy = rc.top - rcParent.top;
+
+        m_uiRelativePos.cx -= (rcPadding.left + rcPadding.right);
+        m_uiRelativePos.cx -= (rcMargin.left + rcMargin.right);
+
+        m_uiRelativePos.cy -= (rcPadding.top + rcPadding.bottom);
+        m_uiRelativePos.cy -= (rcMargin.top + rcMargin.bottom);
+    }
+    else {
+        m_uiRelativePos.Clear();
+    }
+}
+
+UiSize PlaceHolder::GetRelativePos() const
+{
+    if (IsFloat()) {
+        return m_uiRelativePos;
+    }
+    return UiSize();
 }
 
 void PlaceHolder::Invalidate()

--- a/duilib/Core/PlaceHolder.cpp
+++ b/duilib/Core/PlaceHolder.cpp
@@ -27,7 +27,9 @@ PlaceHolder::PlaceHolder(Window* pWindow) :
     m_bEnableControlPadding(true),
     m_bInited(false),
     m_bReEstimateSize(true),
-    m_pEstResult(nullptr)
+    m_pEstResult(nullptr),
+    m_uiFloatPos(INT32_MIN, INT32_MIN),
+    m_bKeepFloatPos(false)
 {
     //控件的高度和宽度值，默认设置为拉伸
     m_cxyFixed.cx.SetStretch();
@@ -539,28 +541,30 @@ void PlaceHolder::SetRect(const UiRect& rc)
     if ((GetParent() != nullptr) && IsFloat()) {
         //浮动控件，则需要记录和父控件相对位置和大小
         UiRect rcParent = GetParent()->GetRect();
-        UiPadding rcPadding = GetParent()->GetPadding();
-        UiMargin rcMargin = GetMargin();
-        m_uiRelativePos.cx = rc.left - rcParent.left;
-        m_uiRelativePos.cy = rc.top - rcParent.top;
-
-        m_uiRelativePos.cx -= (rcPadding.left + rcPadding.right);
-        m_uiRelativePos.cx -= (rcMargin.left + rcMargin.right);
-
-        m_uiRelativePos.cy -= (rcPadding.top + rcPadding.bottom);
-        m_uiRelativePos.cy -= (rcMargin.top + rcMargin.bottom);
+        m_uiFloatPos.cx = rc.left - rcParent.left;
+        m_uiFloatPos.cy = rc.top - rcParent.top;
     }
     else {
-        m_uiRelativePos.Clear();
+        m_uiFloatPos = UiSize(INT32_MIN, INT32_MIN);
     }
 }
 
-UiSize PlaceHolder::GetRelativePos() const
+UiSize PlaceHolder::GetFloatPos() const
 {
-    if (IsFloat()) {
-        return m_uiRelativePos;
+    if (IsFloat() && IsKeepFloatPos()) {
+        return m_uiFloatPos;
     }
-    return UiSize();
+    return UiSize(INT32_MIN, INT32_MIN);
+}
+
+void PlaceHolder::SetKeepFloatPos(bool bKeepFloatPos)
+{
+    m_bKeepFloatPos = bKeepFloatPos;
+}
+
+bool PlaceHolder::IsKeepFloatPos() const
+{
+    return m_bKeepFloatPos;
 }
 
 void PlaceHolder::Invalidate()

--- a/duilib/Core/PlaceHolder.h
+++ b/duilib/Core/PlaceHolder.h
@@ -128,6 +128,10 @@ public:
      */
     void SetFloat(bool bFloat);
 
+    /** 获取与父控件的相对位置(仅当控件为浮动控件时有效)
+    */
+    UiSize GetRelativePos() const;
+
 public:
     /** 获取控件设置的宽度和高度，宽高均包含内边距，但均不包含外边距
     */
@@ -400,6 +404,9 @@ private:
 
     //控件位置与大小
     UiRect m_uiRect;
+
+    //获取与父控件的相对位置(仅当控件为浮动控件时有效)
+    UiSize m_uiRelativePos;
 
     //外部设置的控件大小
     UiFixedSize m_cxyFixed;

--- a/duilib/Core/PlaceHolder.h
+++ b/duilib/Core/PlaceHolder.h
@@ -129,8 +129,17 @@ public:
     void SetFloat(bool bFloat);
 
     /** 获取与父控件的相对位置(仅当控件为浮动控件时有效)
+    * @return 如果返回的cx和cy都是INT32_MIN，表示无效值，其他值表示有效值
     */
-    UiSize GetRelativePos() const;
+    UiSize GetFloatPos() const;
+
+    /** 设置当父控件位置和大小调整时，是否保持浮动控件相对父控件的位置不变
+    */
+    void SetKeepFloatPos(bool bKeepFloatPos);
+
+    /** 获取当父控件位置和大小调整时，是否保持浮动控件相对父控件的位置不变
+    */
+    bool IsKeepFloatPos() const;
 
 public:
     /** 获取控件设置的宽度和高度，宽高均包含内边距，但均不包含外边距
@@ -406,7 +415,7 @@ private:
     UiRect m_uiRect;
 
     //获取与父控件的相对位置(仅当控件为浮动控件时有效)
-    UiSize m_uiRelativePos;
+    UiSize m_uiFloatPos;
 
     //外部设置的控件大小
     UiFixedSize m_cxyFixed;
@@ -442,6 +451,9 @@ private:
 
     //控件是否为浮动属性
     bool m_bFloat;
+
+    //当父控件位置和大小调整时，保持浮动控件相对父控件的位置不变
+    bool m_bKeepFloatPos;
 
     //是否需要布局重排
     bool m_bIsArranged;


### PR DESCRIPTION
Control的Float设置为True后，父Control Resize的时候，导致Control大小和位置被重置 (#135)
增加保持浮动控件与父控件的相对位置的功能，该功能有开关，默认关闭，需要设置XML属性：keep_float_pos="true"开启，或者使用代码SetKeepFloatPos(true); 开启。
