### PR TITLE
使用109cef后，在一些元素上鼠标不会变成手指，老的版本没问题 #211

### DIFF
--- a/duilib/CEFControl/CefControlNative.cpp
+++ b/duilib/CEFControl/CefControlNative.cpp
@@ -86,7 +86,9 @@ void CefControlNative::ReCreateBrowser()
     // 使用有窗模式
     CefWindowInfo window_info;
     //该参数必须显示初始化，不能使用默认值
+#if CEF_VERSION_MAJOR > 109
     window_info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+#endif
     CefRect rect = { GetRect().left, GetRect().top, GetRect().right, GetRect().bottom};
 #ifdef DUILIB_BUILD_FOR_WIN
     //Windows

--- a/duilib/CEFControl/CefControlOffScreen.cpp
+++ b/duilib/CEFControl/CefControlOffScreen.cpp
@@ -139,8 +139,10 @@ void CefControlOffScreen::ReCreateBrowser()
 
     // 使用无窗模式，离屏渲染
     CefWindowInfo window_info;
+#if CEF_VERSION_MAJOR > 109
     //该参数必须显示初始化，不能使用默认值
     window_info.runtime_style = CEF_RUNTIME_STYLE_ALLOY;
+#endif
 
 #ifdef DUILIB_BUILD_FOR_WIN
     HWND hWnd = pWindow->NativeWnd()->GetHWND();

--- a/duilib/CEFControl/internal/CefBrowserHandler.cpp
+++ b/duilib/CEFControl/internal/CefBrowserHandler.cpp
@@ -763,11 +763,18 @@ bool CefBrowserHandler::OnCursorChange(CefRefPtr<CefBrowser> browser,
                                        const CefCursorInfo& custom_cursor_info)
 {
 #ifdef DUILIB_BUILD_FOR_WIN
-    if ((m_pWindow != nullptr) && !m_windowFlag.expired()) {
-        SetClassLongPtr(m_pWindow->NativeWnd()->GetHWND(), GCLP_HCURSOR, static_cast<LONG>(reinterpret_cast<LONG_PTR>(cursor)));
+    if (CefManager::GetInstance()->IsEnableOffScreenRendering()) {
+        //离屏渲染模式：需要设置光标
+        if ((m_pWindow != nullptr) && !m_windowFlag.expired()) {
+            SetClassLongPtr(m_pWindow->NativeWnd()->GetHWND(), GCLP_HCURSOR, static_cast<LONG>(reinterpret_cast<LONG_PTR>(cursor)));
+        }
+        ::SetCursor(cursor);
+        return true;
     }
-    ::SetCursor(cursor);
-    return true;
+    else {
+        //非离屏渲染模式：使用默认行为，不需要设置，否则光标异常
+        return false;
+    }
 #else
     return false;
 #endif

--- a/duilib/Control/Split.h
+++ b/duilib/Control/Split.h
@@ -293,7 +293,12 @@ bool SplitTemplate<InheritType>::ButtonDown(const EventArgs& msg)
     if ((m_pLeftTop != nullptr) && (m_pRightBottom != nullptr)) {
         //如果两个控件都是拉伸类型的，那么让左侧(上侧)的变为非拉伸的，允许拖动操作
         if (m_nLeftUpFixedValue.IsStretch() && m_nRightBottomFixedValue.IsStretch()) {
-            m_nLeftUpFixedValue.SetInt32(m_pLeftTop->GetWidth());
+            if (IsVLayout(pParent)) {
+                m_nLeftUpFixedValue.SetInt32(m_pLeftTop->GetHeight());
+            }
+            else {
+                m_nLeftUpFixedValue.SetInt32(m_pLeftTop->GetWidth());
+            }
         }
     }
     this->Invalidate();

--- a/duilib/Core/Window.cpp
+++ b/duilib/Core/Window.cpp
@@ -2041,17 +2041,17 @@ void Window::SetFocusControl(Control* pControl)
     }
     std::weak_ptr<WeakFlag> windowFlag = GetWeakFlag();
     ControlPtr pOldFocus = m_pFocus;
-    if (m_pFocus != nullptr) {
+    if (pOldFocus != nullptr) {
+        m_pFocus = nullptr;
         //WPARAM 是新的焦点控件接口
         std::weak_ptr<WeakFlag> controlFlag;
         if (pControl != nullptr) {
             controlFlag = pControl->GetWeakFlag();
         }        
-        m_pFocus->SendEvent(kEventKillFocus, (WPARAM)pControl);
+        pOldFocus->SendEvent(kEventKillFocus, (WPARAM)pControl);
         if (windowFlag.expired()) {
             return;
-        }
-        m_pFocus = nullptr;
+        }        
         if ((pControl != nullptr) && controlFlag.expired()){
             //该控件已经销毁
             OnFocusControlChanged();

--- a/duilib/Utils/ShadowWnd.h
+++ b/duilib/Utils/ShadowWnd.h
@@ -21,6 +21,7 @@ class ShadowWnd: public WindowImplBase
     typedef WindowImplBase BaseClass;
 public:
     ShadowWnd();
+    virtual ~ShadowWnd() override;
 
 protected:
     /** 附加窗口阴影

--- a/duilib/Utils/ShadowWnd_SDL.cpp
+++ b/duilib/Utils/ShadowWnd_SDL.cpp
@@ -136,6 +136,10 @@ ShadowWnd::ShadowWnd():
 {
 }
 
+ShadowWnd::~ShadowWnd()
+{
+}
+
 Box* ShadowWnd::AttachShadow(Box* pRoot)
 {
     if (pRoot == nullptr) {

--- a/duilib/Utils/ShadowWnd_Windows.cpp
+++ b/duilib/Utils/ShadowWnd_Windows.cpp
@@ -84,6 +84,8 @@ LRESULT ShadowWndBase::FilterMessage(UINT uMsg, WPARAM wParam, LPARAM /*lParam*/
             break;
         case WM_CLOSE:
             ShowWindow(kSW_HIDE);
+            //关联窗口关闭时，销毁阴影
+            CloseWnd();
             break;
         case WM_SHOWWINDOW:
             if (wParam == 0) {
@@ -101,6 +103,10 @@ LRESULT ShadowWndBase::FilterMessage(UINT uMsg, WPARAM wParam, LPARAM /*lParam*/
 
 ShadowWnd::ShadowWnd():
     m_pShadowWnd(nullptr)
+{
+}
+
+ShadowWnd::~ShadowWnd()
 {
 }
 


### PR DESCRIPTION
使用109cef后，在一些元素上鼠标不会变成手指，老的版本没问题 #211
修复Bug：NativeWindow_Windows::WindowBaseFromPoint可能使用非法指针（pWindow），导致程序崩溃。
