### PR TITLE
ShadowWnd 关闭后残留 #205（修复子窗口不显示的问题，重现条件：Release版本。问题原因：SkRasterWindowContext_Windows的成员变量fWidth和fHeight在构造函数中未正确初始化，导致resize函数中使用了未初始化的值）

### DIFF
--- a/bin/resources/themes/default/cef/drop_files.html
+++ b/bin/resources/themes/default/cef/drop_files.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>文件拖放示例</title>
+    <script>
+        //JS/C++通信的函数
+        const SendDropFilesToBrowser = (files) => {
+            // 调用一个 C++ 已经注册过的方法，将拖放的文件名传给主进程（json格式，网页无法获取到完整路径）
+            NimCefWebInstance.call('OnDropFilesToBrowser', files, (error, result) => {
+                console.log(result)
+            })
+        }
+    </script>
+    <style>
+        .drop-zone {
+            border: 2px dashed #ccc;
+            padding: 20px;
+            text-align: center;
+            width: 400px;
+            margin: 20px auto;
+            cursor: pointer;
+            transition: background-color 0.3s;
+        }
+        
+        .drop-zone.active {
+            background-color: #e9f5ff;
+            border-color: #2196F3;
+        }
+        
+        .file-list {
+            margin-top: 20px;
+            text-align: left;
+        }
+        
+        .file-item {
+            display: flex;
+            align-items: flex-start;
+            margin: 10px 0;
+            padding: 10px;
+            border-radius: 5px;
+            background-color: #f8f9fa;
+            border-left: 3px solid #2196F3;
+            transition: transform 0.2s;
+        }
+        
+        .file-item:hover {
+            transform: translateX(2px);
+        }
+        
+        .file-icon {
+            margin-right: 10px;
+            color: #2196F3;
+            font-size: 1.5em;
+        }
+        
+        .file-details {
+            flex: 1;
+        }
+        
+        .file-name {
+            font-weight: bold;
+        }
+        
+        .file-path {
+            font-size: 0.9em;
+            color: #6c757d;
+            margin-top: 2px;
+        }
+        
+        .file-meta {
+            display: flex;
+            gap: 15px;
+            font-size: 0.8em;
+            color: #6c757d;
+            margin-top: 2px;
+        }
+        
+        .file-content-preview {
+            margin-top: 8px;
+            padding: 8px;
+            background-color: #e9ecef;
+            border-radius: 3px;
+            font-size: 0.9em;
+            white-space: pre-wrap;
+            overflow: hidden;
+            max-height: 200px;
+            transition: max-height 0.3s;
+            position: relative;
+        }
+        
+        .file-content-preview.expanded {
+            max-height: none;
+        }
+        
+        .expand-button {
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            background: rgba(233, 236, 239, 0.8);
+            color: #2196F3;
+            border: none;
+            padding: 2px 5px;
+            font-size: 0.8em;
+            cursor: pointer;
+            display: none;
+        }
+        
+        .file-content-preview:hover .expand-button {
+            display: block;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h3>拖放文件到下方区域</h3>
+        
+        <div id="dropZone" class="drop-zone">
+            <i class="file-icon">📁</i>
+            <p>拖放文件到这里</p>
+            <p>或者</p>
+            <button id="browseBtn">选择文件</button>
+            <input type="file" id="fileInput" multiple style="display: none;">
+        </div>
+        
+        <div class="file-list" id="fileList"></div>
+        <button onclick="showFilesInfo()">查看文件信息列表</button>
+        <pre id="filesInfoOutput"></pre>
+    </div>
+
+    <script>
+        // 存储当前拖放的文件信息
+        let droppedFiles = [];
+
+        const dropZone = document.getElementById('dropZone');
+        const fileInput = document.getElementById('fileInput');
+        const browseBtn = document.getElementById('browseBtn');
+        const fileList = document.getElementById('fileList');
+        const filesInfoOutput = document.getElementById('filesInfoOutput');
+
+        // 阻止默认拖放行为
+        ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+            dropZone.addEventListener(eventName, preventDefaults, false);
+            document.body.addEventListener(eventName, preventDefaults, false);
+        });
+
+        function preventDefaults(e) {
+            e.preventDefault();
+            e.stopPropagation();
+        }
+
+        // 高亮拖放区域
+        ['dragenter', 'dragover'].forEach(eventName => {
+            dropZone.addEventListener(eventName, highlight, false);
+        });
+
+        ['dragleave', 'drop'].forEach(eventName => {
+            dropZone.addEventListener(eventName, unhighlight, false);
+        });
+
+        function highlight() {
+            dropZone.classList.add('active');
+        }
+
+        function unhighlight() {
+            dropZone.classList.remove('active');
+        }
+
+        // 处理文件拖放
+        dropZone.addEventListener('drop', handleDrop, false);
+
+        function handleDrop(e) {
+            const dt = e.dataTransfer;
+            const files = dt.files;
+            handleFiles(files);
+        }
+
+        // 处理文件选择
+        browseBtn.addEventListener('click', () => {
+            fileInput.click();
+        });
+
+        fileInput.addEventListener('change', () => {
+            handleFiles(fileInput.files);
+        });
+
+        // 处理文件列表
+        function handleFiles(files) {
+            if (files.length > 0) {
+                // 清空之前的文件信息
+                droppedFiles = [];
+                fileList.innerHTML = '';
+                
+                // 遍历文件并显示
+                Array.from(files).forEach(file => {
+                    const fileId = createUniqueId();
+                    // 存储文件信息
+                    droppedFiles.push({
+                        name: file.name,
+                        size: file.size,
+                        sizeFormatted: formatFileSize(file.size),
+                        type: file.type || '未知',
+                        path: getFileInfo(file)
+                    });
+                    
+                    displayFile(file, fileId);
+                    processFile(file, fileId);
+                });
+                
+                // 显示文件信息已更新
+                console.log('文件信息列表已更新:', getDroppedFilesInfo());
+            }
+            
+            //发送给C++端
+            SendDropFilesToBrowser(getDroppedFilesInfo())
+        }
+
+        // 创建唯一ID
+        function createUniqueId() {
+            return `file-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+        }
+
+        // 获取文件路径信息
+        function getFileInfo(file) {
+            // 尝试获取webkitRelativePath（用于目录选择）
+            let pathInfo = file.webkitRelativePath || '';
+            
+            // 如果没有相对路径，使用文件名
+            if (!pathInfo) {
+                pathInfo = file.name;
+            }
+            
+            return pathInfo;
+        }
+
+        // 格式化文件大小
+        function formatFileSize(bytes) {
+            if (bytes === 0) return '0 Bytes';
+            
+            const units = ['Bytes', 'KB', 'MB', 'GB'];
+            const unitIndex = Math.floor(Math.log(bytes) / Math.log(1024));
+            const size = parseFloat((bytes / Math.pow(1024, unitIndex)).toFixed(2));
+            
+            return `${size} ${units[unitIndex]}`;
+        }
+
+        // HTML安全转义
+        function escapeHTML(str) {
+            if (!str) return '';
+            return str
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        // 显示文件信息
+        function displayFile(file, fileId) {
+            const fileInfo = getFileInfo(file);
+            
+            const fileItem = document.createElement('div');
+            fileItem.className = 'file-item';
+            fileItem.id = fileId;
+            fileItem.innerHTML = `
+                <i class="file-icon">📄</i>
+                <div class="file-details">
+                    <div class="file-name">${escapeHTML(file.name)}</div>
+                    <div class="file-path">路径: ${escapeHTML(fileInfo)}</div>
+                    <div class="file-meta">
+                        <span>大小: ${formatFileSize(file.size)}</span>
+                        <span>类型: ${escapeHTML(file.type || '未知')}</span>
+                    </div>
+                    <div class="file-content-preview" id="preview-${fileId}">
+                        <i>读取文件内容中...</i>
+                    </div>
+                </div>
+            `;
+            fileList.appendChild(fileItem);
+        }
+
+        // 处理文件（读取内容并显示预览）
+        function processFile(file, fileId) {
+            console.log('处理文件:', file.name);
+            
+            // 对于文本类型文件，读取内容并显示预览
+            const isTextFile = 
+                file.type.startsWith('text/') || 
+                file.name.endsWith('.txt') || 
+                file.name.endsWith('.json') || 
+                file.name.endsWith('.html') || 
+                file.name.endsWith('.js') || 
+                file.name.endsWith('.css') ||
+                file.name.endsWith('.xml') ||
+                file.name.endsWith('.md');
+            
+            const previewElement = document.getElementById(`preview-${fileId}`);
+            
+            if (isTextFile) {
+                const reader = new FileReader();
+                
+                reader.onload = function(e) {
+                    const content = e.target.result;
+                    
+                    // 为长内容添加展开/折叠功能
+                    const truncatedContent = content.length > 1000 
+                        ? content.substring(0, 1000) + '... [点击展开]' 
+                        : content;
+                    
+                    // 在控制台打印完整内容
+                    console.log('文件完整内容:', content);
+                    
+                    // 在页面上显示预览
+                    if (previewElement) {
+                        previewElement.textContent = truncatedContent;
+                        
+                        // 如果内容被截断，添加展开功能
+                        if (content.length > 1000) {
+                            previewElement.innerHTML += `
+                                <button class="expand-button" onclick="toggleContent('${fileId}')">
+                                    展开
+                                </button>
+                            `;
+                        }
+                    }
+                };
+                
+                reader.onerror = function() {
+                    if (previewElement) {
+                        previewElement.innerHTML = '<span style="color: red;">无法读取文件内容</span>';
+                    }
+                };
+                
+                // 尝试检测文件编码
+                try {
+                    reader.readAsText(file);
+                } catch (e) {
+                    // 默认使用UTF-8
+                    reader.readAsText(file, 'UTF-8');
+                }
+            } else {
+                // 非文本文件显示类型信息
+                if (previewElement) {
+                    previewElement.innerHTML = `
+                        <div style="color: #6c757d;">
+                            <i class="file-icon">📎</i>
+                            非文本文件 (${escapeHTML(file.type || '未知类型')})
+                        </div>
+                    `;
+                }
+            }
+        }
+
+        // 展开/折叠内容
+        function toggleContent(fileId) {
+            const previewElement = document.getElementById(`preview-${fileId}`);
+            const button = previewElement.querySelector('.expand-button');
+            
+            if (previewElement.classList.contains('expanded')) {
+                // 折叠内容
+                previewElement.classList.remove('expanded');
+                button.textContent = '展开';
+            } else {
+                // 展开内容
+                previewElement.classList.add('expanded');
+                button.textContent = '折叠';
+            }
+        }
+
+        // 获取拖放的文件信息列表
+        function getDroppedFilesInfo() {
+            return droppedFiles.map(file => ({
+                name: file.name,
+                size: file.size
+            }));
+        }
+
+        // 显示文件信息列表（用于测试）
+        function showFilesInfo() {
+            const filesInfo = getDroppedFilesInfo();
+            filesInfoOutput.textContent = JSON.stringify(filesInfo, null, 2);
+        }
+    </script>
+</body>
+</html>

--- a/duilib/CEFControl/CefControl.cpp
+++ b/duilib/CEFControl/CefControl.cpp
@@ -712,6 +712,29 @@ void CefControl::OnMediaAccessChange(CefRefPtr<CefBrowser> browser, bool has_vid
     }
 }
 
+bool CefControl::OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask)
+{
+    bool bRet = false;
+    if (m_pfnDragEnter) {
+        bRet = m_pfnDragEnter(browser, dragData, mask);
+    }
+    else if (m_pCefControlEventHandler) {
+        bRet = m_pCefControlEventHandler->OnDragEnter(browser, dragData, mask);
+    }
+    return bRet;
+}
+
+void CefControl::OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions)
+{
+    GlobalManager::Instance().AssertUIThread();
+    if (m_pfnDraggableRegionsChanged) {
+        m_pfnDraggableRegionsChanged(browser, frame, regions);
+    }
+    else if (m_pCefControlEventHandler) {
+        m_pCefControlEventHandler->OnDraggableRegionsChanged(browser, frame, regions);
+    }
+}
+
 void CefControl::OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bool isLoading, bool canGoBack, bool canGoForward)
 {
     GlobalManager::Instance().AssertUIThread();
@@ -1073,6 +1096,8 @@ bool CefControl::IsCallbackExists(CefCallbackID nCallbackID)
     case CefCallbackID::OnDownloadUpdated:          return m_pfnDownloadUpdated != nullptr;
     case CefCallbackID::OnFileDialog:               return m_pfnFileDialog != nullptr;
     case CefCallbackID::OnDocumentAvailableInMainFrame: return m_pfnDocumentAvailableInMainFrame != nullptr;
+    case CefCallbackID::OnDragEnter:                    return m_pfnDragEnter != nullptr;
+    case CefCallbackID::OnDraggableRegionsChanged:      return m_pfnDraggableRegionsChanged != nullptr;
     default:
         break;
     }

--- a/duilib/CEFControl/CefControl.h
+++ b/duilib/CEFControl/CefControl.h
@@ -243,6 +243,16 @@ public:
     */
     void AttachMediaAccessChange(OnMediaAccessChangeEvent callback) { m_pfnMediaAccessChange = callback; }
 
+    /** 绑定一个回调函数用于监听页面的拖动操作（回调函数的调用线程：CEF的UI线程）
+    * @param [in] callback 一个回调函数，参考 OnDragEnterEvent 声明
+    */
+    void AttachDragEnter(OnDragEnterEvent callback) { m_pfnDragEnter = callback; }
+
+    /** 绑定一个回调函数用于监听页面的可拖动区域变化（回调函数的调用线程：主线程的UI线程）
+    * @param [in] callback 一个回调函数，参考 OnDraggableRegionsChangedEvent 声明
+    */
+    void AttachDraggableRegionsChanged(OnDraggableRegionsChangedEvent callback) { m_pfnDraggableRegionsChanged = callback; }
+
     /** 绑定一个回调函数用于监听一个弹出窗口弹出的通知（回调函数的调用线程：CEF的UI线程）
     * @param [in] callback 一个回调函数，参考 OnBeforePopupEvent 声明
     */
@@ -416,6 +426,10 @@ protected:
     virtual void OnStatusMessage(CefRefPtr<CefBrowser> browser, const DString& value) override;
     virtual void OnLoadingProgressChange(CefRefPtr<CefBrowser> browser, double progress) override;
     virtual void OnMediaAccessChange(CefRefPtr<CefBrowser> browser, bool has_video_access, bool has_audio_access) override;
+
+    //CefDragHandler接口的实现
+    virtual bool OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask) override;
+    virtual void OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions) override;
 
     //CefLoadHandler接口
     virtual void OnLoadingStateChange(CefRefPtr<CefBrowser> browser, bool isLoading, bool canGoBack, bool canGoForward) override;
@@ -621,6 +635,8 @@ private:
     OnDevToolAttachedStateChangeEvent   m_pfnDevToolVisibleChange = nullptr;
     OnDocumentAvailableInMainFrameEvent m_pfnDocumentAvailableInMainFrame = nullptr;
     OnDownloadFavIconFinishedEvent      m_pfnDownloadFavIconFinished = nullptr;
+    OnDragEnterEvent                    m_pfnDragEnter = nullptr;
+    OnDraggableRegionsChangedEvent      m_pfnDraggableRegionsChanged = nullptr;
 
     /** CEF控件的事件回调接口
     */

--- a/duilib/CEFControl/CefControlEvent.h
+++ b/duilib/CEFControl/CefControlEvent.h
@@ -206,6 +206,17 @@ namespace ui
                                 const CefString& image_url,
                                 int http_status_code,
                                 CefRefPtr<CefImage> image)> OnDownloadFavIconFinishedEvent;
+
+    //CefDragHandler接口
+    //拖动操作（回调函数的调用线程：CEF的UI线程）
+    typedef std::function<bool (CefRefPtr<CefBrowser> browser,
+                                CefRefPtr<CefDragData> dragData,
+                                CefDragHandler::DragOperationsMask mask)> OnDragEnterEvent;
+    //可拖动区域发生变化（回调函数的调用线程：主进程的UI线程）
+    typedef std::function<void (CefRefPtr<CefBrowser> browser,
+                                CefRefPtr<CefFrame> frame,
+                                const std::vector<CefDraggableRegion>& regions)> OnDraggableRegionsChangedEvent;
+
 }
 
 namespace ui
@@ -405,6 +416,13 @@ public:
                                            const CefString& image_url,
                                            int http_status_code,
                                            CefRefPtr<CefImage> image) {}
+
+    //CefDragHandler接口
+    //拖动操作（回调函数的调用线程：CEF的UI线程）
+    virtual bool OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask) { return false; };
+
+    //可拖动区域发生变化（回调函数的调用线程：主进程的UI线程）
+    virtual void OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions) {};
 
 public:
     virtual ~CefControlEvent() = default;

--- a/duilib/CEFControl/internal/CefBrowserHandler.cpp
+++ b/duilib/CEFControl/internal/CefBrowserHandler.cpp
@@ -791,11 +791,17 @@ void CefBrowserHandler::OnMediaAccessChange(CefRefPtr<CefBrowser> browser,
 
 bool CefBrowserHandler::OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask)
 {
+    if (m_pHandlerDelegate) {
+        return m_pHandlerDelegate->OnDragEnter(browser, dragData, mask);
+    }
     return false;
 }
 
 void CefBrowserHandler::OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions)
 {
+    if (m_pHandlerDelegate && m_pHandlerDelegate->IsCallbackExists(CefCallbackID::OnDraggableRegionsChanged)) {
+        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, UiBind(&CefBrowserHandlerDelegate::OnDraggableRegionsChanged, m_pHandlerDelegate, browser, frame, regions));
+    }
 }
 
 // CefLoadHandler methods

--- a/duilib/CEFControl/internal/CefBrowserHandlerDelegate.h
+++ b/duilib/CEFControl/internal/CefBrowserHandlerDelegate.h
@@ -149,6 +149,10 @@ public:
                             const CefKeyEvent& event,
                             CefEventHandle os_event) = 0 ;
 
+    //CefDragHandler接口
+    virtual bool OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask) = 0;
+    virtual void OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions) = 0;
+
 public:
     /** 客户区坐标转换为控件坐标
     */
@@ -220,6 +224,8 @@ enum class CefCallbackID
     OnFileDialog,
     OnPreKeyEvent,
     OnKeyEvent,
+    OnDragEnter,
+    OnDraggableRegionsChanged
 };
 
 }//namespace ui

--- a/duilib/Core/NativeWindow_Windows.h
+++ b/duilib/Core/NativeWindow_Windows.h
@@ -618,6 +618,10 @@ private:
     */
     HWND m_hWnd;
 
+    /** 创建时指定的父窗口
+    */
+    HWND m_hParentWnd;
+
     /** 资源模块句柄
     */
     HMODULE m_hResModule;

--- a/duilib/RenderSkia/SkRasterWindowContext_SDL.cpp
+++ b/duilib/RenderSkia/SkRasterWindowContext_SDL.cpp
@@ -48,10 +48,14 @@ void SkRasterWindowContext_SDL::resize(int nWidth, int nHeight)
         nHeight = 0;
     }
     if ((fWidth == nWidth) && (fHeight == nHeight)) {
+        if ((fWidth > 0) && (fHeight > 0)) {
+            SkASSERT(m_fSurfaceMemory != nullptr);
+            SkASSERT(m_fBackbufferSurface != nullptr);
+        }
         return;
     }
     const skwindow::DisplayParams* pDisplayParams = getDisplayParams();
-    ASSERT(pDisplayParams != nullptr);
+    SkASSERT(pDisplayParams != nullptr);
     if (pDisplayParams == nullptr) {
         return;
     }
@@ -69,8 +73,11 @@ void SkRasterWindowContext_SDL::resize(int nWidth, int nHeight)
 
     m_fSurfaceMemory.reset(nWidth * nHeight * sizeof(uint32_t));
     void* pixels = m_fSurfaceMemory.get();
-    ASSERT(pixels != nullptr);
+    SkASSERT(pixels != nullptr);
     if (pixels == nullptr) {
+        m_fSurfaceMemory.reset();
+        fWidth = 0;
+        fHeight = 0;
         return;
     }
 
@@ -80,6 +87,13 @@ void SkRasterWindowContext_SDL::resize(int nWidth, int nHeight)
     if (m_sdlTextrue != nullptr) {
         SDL_DestroyTexture(m_sdlTextrue);
         m_sdlTextrue = nullptr;
+    }
+
+    if (m_fBackbufferSurface == nullptr) {
+        m_fSurfaceMemory.reset();
+        fWidth = 0;
+        fHeight = 0;
+        return;
     }
 }
 

--- a/duilib/Utils/ShadowWnd_Windows.cpp
+++ b/duilib/Utils/ShadowWnd_Windows.cpp
@@ -62,10 +62,12 @@ LRESULT ShadowWndBase::FilterMessage(UINT uMsg, WPARAM wParam, LPARAM /*lParam*/
         case WM_ERASEBKGND:
         case WM_PAINT:
         case WM_MOVE:
+        case WM_MOVING:
         case WM_SIZE:
         case WM_SIZING:
         case WM_WINDOWPOSCHANGING:
         case WM_WINDOWPOSCHANGED:
+        case WM_CAPTURECHANGED:
         case WM_ACTIVATE:
         case WM_NCACTIVATE:
             if ((uMsg != WM_PAINT) || ((uMsg == WM_PAINT) && !m_isFirstPainted)) {
@@ -96,6 +98,16 @@ LRESULT ShadowWndBase::FilterMessage(UINT uMsg, WPARAM wParam, LPARAM /*lParam*/
             }
             break;
         default:
+            if (m_pWindow->IsWindowVisible()) {
+                if (::GetWindow(m_pWindow->NativeWnd()->GetHWND(), GW_HWNDNEXT) != NativeWnd()->GetHWND()) {
+                    UiRect rc;
+                    m_pWindow->GetWindowRect(rc);
+                    UiPadding rcShadow;
+                    GetCurrentShadowCorner(rcShadow);
+                    rc.Inflate(rcShadow);
+                    SetWindowPos(InsertAfterWnd(m_pWindow), rc.left, rc.top, rc.Width(), rc.Height(), kSWP_SHOWWINDOW | kSWP_NOACTIVATE);
+                }                
+            }            
             break;
     }
     return 0;

--- a/examples/CefBrowser/browser/BrowserBox.cpp
+++ b/examples/CefBrowser/browser/BrowserBox.cpp
@@ -53,6 +53,9 @@ void BrowserBox::InitBrowserBox(const DString& url)
     m_pCefControl->AttachLoadingProgressChange(ui::UiBind(&BrowserBox::OnLoadingProgressChange, this, std::placeholders::_1, std::placeholders::_2));
     m_pCefControl->AttachMediaAccessChange(ui::UiBind(&BrowserBox::OnMediaAccessChange, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
 
+    m_pCefControl->AttachDragEnter(ui::UiBind(&BrowserBox::OnDragEnter, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    m_pCefControl->AttachDraggableRegionsChanged(ui::UiBind(&BrowserBox::OnDraggableRegionsChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+
     m_pCefControl->AttachBeforePopup(ui::UiBind(&BrowserBox::OnBeforePopup, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7, std::placeholders::_8, std::placeholders::_9, std::placeholders::_10));
     m_pCefControl->AttachBeforePopupAborted(ui::UiBind(&BrowserBox::OnBeforePopupAborted, this, std::placeholders::_1, std::placeholders::_2));
     m_pCefControl->AttachBeforeBrowse(ui::UiBind(&BrowserBox::OnBeforeBrowse, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5));
@@ -233,6 +236,16 @@ void BrowserBox::OnLoadingProgressChange(CefRefPtr<CefBrowser> browser, double p
 }
 
 void BrowserBox::OnMediaAccessChange(CefRefPtr<CefBrowser> browser, bool has_video_access, bool has_audio_access)
+{
+    ui::GlobalManager::Instance().AssertUIThread();
+}
+
+bool BrowserBox::OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask)
+{
+    return false;
+}
+
+void BrowserBox::OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions)
 {
     ui::GlobalManager::Instance().AssertUIThread();
 }

--- a/examples/CefBrowser/browser/BrowserBox.h
+++ b/examples/CefBrowser/browser/BrowserBox.h
@@ -136,6 +136,14 @@ protected:
     */
     void OnMediaAccessChange(CefRefPtr<CefBrowser> browser, bool has_video_access, bool has_audio_access);
 
+    /** CefDragHandler接口的事件：开始拖动（回调函数的调用线程：CEF的UI线程）
+    */
+    bool OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask);
+
+    /** CefDragHandler接口的事件：可拖动区域发生变化（回调函数的调用线程：主进程的UI线程）
+    */
+    void OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions);
+
     /** 点击了超级链接，即将弹出新窗口（回调函数的调用线程：CEF的UI线程）
     */
     bool OnBeforePopup(CefRefPtr<CefBrowser> browser,

--- a/examples/cef/CefForm.h
+++ b/examples/cef/CefForm.h
@@ -113,6 +113,15 @@ private:
     */
     virtual void OnMediaAccessChange(CefRefPtr<CefBrowser> browser, bool has_video_access, bool has_audio_access) override;
 
+    /** CefDragHandler接口的事件：开始拖动（回调函数的调用线程：CEF的UI线程）
+    */
+    virtual bool OnDragEnter(CefRefPtr<CefBrowser> browser, CefRefPtr<CefDragData> dragData, CefDragHandler::DragOperationsMask mask) override;
+
+    /** CefDragHandler接口的事件：可拖动区域发生变化（回调函数的调用线程：主进程的UI线程）
+    */
+    virtual void OnDraggableRegionsChanged(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const std::vector<CefDraggableRegion>& regions) override;
+
+
     /** 点击了超级链接，即将弹出新窗口（回调函数的调用线程：CEF的UI线程）
     */
     virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser,
@@ -248,11 +257,19 @@ private:
     */
     void OnDevToolVisibleStateChanged(bool bVisible, bool bPopup);
 
+    /** 拖入文件操作业务处理
+    */
+    void OnDropFiles(const DString& jsonDropFileList);
+
 private:
     ui::CefControl* m_pCefControl;
     ui::CefControl* m_pCefControlDev;
     ui::Button* m_pDevToolBtn;
     ui::RichEdit* m_pEditUrl;
+
+    /** 拖入文件操作: 记录文件列表
+    */
+    std::vector<CefString> m_dropFileList;
 };
 
 #endif //EXAMPLES_CEF_FORM_H_


### PR DESCRIPTION
ShadowWnd 关闭后残留 #205（修复子窗口不显示的问题，重现条件：Release版本。问题原因：SkRasterWindowContext_Windows的成员变量fWidth和fHeight在构造函数中未正确初始化，导致resize函数中使用了未初始化的值）
