### PR TITLE
CEF控件离屏渲染模式的光标支持

### DIFF
--- a/bin/resources/themes/default/MultiLang/MultiLang.xml
+++ b/bin/resources/themes/default/MultiLang/MultiLang.xml
@@ -4,8 +4,8 @@
     <VBox bkcolor="bk_wnd_darkcolor" visible="true">    
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label text_id="MULTI_LANG_WINDOW_TEXT" height="32" width="stretch" margin="8,2,0,2" text_align="vcenter,left"/>
-            <Control width="40"/>
+            <Label text_id="MULTI_LANG_WINDOW_TEXT" height="32" width="stretch" margin="8,2,0,2" text_align="vcenter,left" mouse="false"/>
+            <Control width="40" mouse="false"/>
             <Button class="btn_language" height="32" width="40" name="language" margin="0,2,0,2" tooltip_textid="MULTI_LANG_SELECT_LANGUAGE"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_textid="MULTI_LANG_SELECT_WINDOW_MIN"/>
             <Box height="stretch" width="40" margin="0,2,0,2">

--- a/bin/resources/themes/default/basic/basic.xml
+++ b/bin/resources/themes/default/basic/basic.xml
@@ -6,7 +6,7 @@
     <VBox bkcolor="bk_wnd_darkcolor" visible="true">    
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Control />
+            <Control mouse="false"/>
             <Button class="btn_wnd_fullscreen_11" height="32" width="40" name="fullscreenbtn" margin="0,2,0,2" tooltip_text="全屏，按ESC键可退出全屏"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">

--- a/bin/resources/themes/default/cef/cef.xml
+++ b/bin/resources/themes/default/cef/cef.xml
@@ -3,7 +3,7 @@
     <VBox bkcolor="bk_wnd_darkcolor">
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label name="page_title" width="stretch" height="32" text_align="left,vcenter" text_padding="8,2,5,0"/>
+            <Label name="page_title" width="stretch" height="32" text_align="left,vcenter" text_padding="8,2,5,0" mouse="false"/>
             <Button name="btn_dev_tool" height="32" width="40" margin="0,2,4,2" valign="center" 
                           tooltip_text="开发者工具" bkimage="file='dev_tool.svg' height='20' width='20' halign='center' valign='center'"
                           hot_color="AliceBlue" pushed_color="Lavender"/>

--- a/bin/resources/themes/default/cef_browser/cef_browser.xml
+++ b/bin/resources/themes/default/cef_browser/cef_browser.xml
@@ -25,8 +25,8 @@
 		
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="auto" height="36" bkcolor="">
-            <Control />
-            <Control width="36"/>
+            <Control mouse="false"/>
+            <Control width="36" mouse="false"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">
                 <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/bin/resources/themes/default/controls/about.xml
+++ b/bin/resources/themes/default/controls/about.xml
@@ -3,8 +3,8 @@
   <VBox bkcolor="bk_wnd_darkcolor" width="100%" height="100%">
     <HBox name="window_caption_bar" width="stretch" height="35" bkcolor="bk_wnd_lightcolor">
       <Control width="18" height="18" bkimage="public/caption/logo.svg" valign="center" margin="8"/>
-      <Label text="Controls" valign="center" margin="8"/>
-      <Control />
+      <Label text="Controls" valign="center" margin="8" mouse="false"/>
+      <Control mouse="false"/>
       <Button class="btn_wnd_close_11" name="closebtn" width="40" height="32" margin="4,0,0,0"/>
     </HBox>
     <Box>

--- a/bin/resources/themes/default/controls/controls.xml
+++ b/bin/resources/themes/default/controls/controls.xml
@@ -6,8 +6,8 @@
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
             <Control width="18" height="18" bkimage="public/caption/logo.svg" valign="center" margin="8"/>
-            <Label name="window_title" text="Controls" valign="center" margin="8"/>
-            <Control />
+            <Label name="window_title" text="Controls" valign="center" margin="8" mouse="false"/>
+            <Control mouse="false"/>
             <Button class="btn_wnd_settings_11" height="32" width="40" name="settings" margin="0,2,0,2" tooltip_text="设置"/>            
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">

--- a/bin/resources/themes/default/dpi_aware/DpiAware.xml
+++ b/bin/resources/themes/default/dpi_aware/DpiAware.xml
@@ -3,7 +3,7 @@
     <VBox bkcolor="bk_wnd_darkcolor" visible="true">    
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Control />
+            <Control mouse="false"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">
                 <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/bin/resources/themes/default/list_box/list_box.xml
+++ b/bin/resources/themes/default/list_box/list_box.xml
@@ -2,7 +2,7 @@
 <Window size="540,720" caption="0,0,0,36" use_system_caption="false" shadow_attached="true" layered_window="true" size_box="4,4,4,4">
     <VBox bkcolor="bk_wnd_darkcolor">
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label text="列表（VTileListBox | HTileListBox | VListBox | HListBox）" font="system_14" valign="center" margin="8" width="stretch"/>
+            <Label text="列表（VTileListBox | HTileListBox | VListBox | HListBox）" font="system_14" valign="center" margin="8" width="stretch" mouse="false"/>
             <HBox width="auto">
                 <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
                 <Box height="stretch" width="40" margin="0,2,0,2">

--- a/bin/resources/themes/default/list_ctrl/list_ctrl.xml
+++ b/bin/resources/themes/default/list_ctrl/list_ctrl.xml
@@ -3,7 +3,7 @@
     <VBox bkcolor="bk_wnd_darkcolor" visible="true">    
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Control />
+            <Control mouse="false"/>
             <Button class="btn_wnd_fullscreen_11" height="32" width="40" name="fullscreenbtn" margin="0,2,0,2" tooltip_text="全屏，按ESC键可退出全屏"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">

--- a/bin/resources/themes/default/move_control/main.xml
+++ b/bin/resources/themes/default/move_control/main.xml
@@ -4,8 +4,8 @@
     <VBox>
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label text="应用列表" font="system_bold_14" margin="10,10"/>
-            <Control />
+            <Label text="应用列表" font="system_bold_14" margin="10,10" mouse="false"/>
+            <Control mouse="false"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">
                 <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/bin/resources/themes/default/my_duilib_app/MyDuilibForm.xml
+++ b/bin/resources/themes/default/my_duilib_app/MyDuilibForm.xml
@@ -6,7 +6,7 @@
     <VBox bkcolor="bk_wnd_darkcolor" visible="true">    
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Control />
+            <Control mouse="false"/>
             <Button class="btn_wnd_fullscreen_11" height="32" width="40" name="fullscreenbtn" margin="0,2,0,2" tooltip_text="全屏，按ESC键可退出全屏"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">

--- a/bin/resources/themes/default/public/color/color_picker.xml
+++ b/bin/resources/themes/default/public/color/color_picker.xml
@@ -11,8 +11,8 @@
     
     <!-- 标题栏区域 -->
     <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-        <Label text="选择颜色" valign="center" margin="8"/>
-        <Control />
+        <Label text="选择颜色" valign="center" margin="8" mouse="false"/>
+        <Control mouse="false"/>
         <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
         <Box height="stretch" width="40" margin="0,2,0,2">
             <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/bin/resources/themes/default/render/render.xml
+++ b/bin/resources/themes/default/render/render.xml
@@ -5,11 +5,11 @@
         <!-- 标题栏区域 -->  
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
             <!-- 标题栏：窗口左上角显示区域 -->  
-            <HBox margin="0,0,30,0" valign="center" width="auto" height="auto">
+            <HBox margin="0,0,30,0" valign="center" width="auto" height="auto" mouse="false">
                 <Control width="18" height="18" bkimage="public/caption/logo.svg" valign="center" margin="8,0,0,0"/>
-                <Label text="渲染引擎测试" valign="center" margin="8,0,0,0"/>
+                <Label text="渲染引擎测试" valign="center" margin="8,0,0,0" mouse="false"/>
             </HBox>
-            <Control />            
+            <Control mouse="false"/>            
             <!-- 标题栏：右侧窗口控制区域，窗口最小化、最大化、还原、关闭按钮 -->
             <HBox margin="0,0,0,0" valign="center" width="auto" height="36">
                 <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>

--- a/bin/resources/themes/default/rich_edit/rich_edit.xml
+++ b/bin/resources/themes/default/rich_edit/rich_edit.xml
@@ -10,11 +10,11 @@
         <!-- 标题栏区域 -->  
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
             <!-- 标题栏：窗口左上角显示区域 -->  
-            <HBox margin="0,0,30,0" valign="center" width="auto" height="auto">
+            <HBox margin="0,0,30,0" valign="center" width="auto" height="auto" mouse="false">
                 <Control width="18" height="18" bkimage="public/caption/logo.svg" valign="center" margin="8,0,0,0"/>
-                <Label text="RichEdit控件测试程序" valign="center" margin="8,0,0,0"/>
+                <Label text="RichEdit控件测试程序" valign="center" margin="8,0,0,0" mouse="false"/>
             </HBox>
-            <Control />
+            <Control mouse="false"/>
             <!-- 标题栏：右侧窗口控制区域，窗口最小化、最大化、还原、关闭按钮 -->
             <HBox margin="0,0,0,0" valign="center" width="auto" height="36">
                 <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>

--- a/bin/resources/themes/default/threads/threads.xml
+++ b/bin/resources/themes/default/threads/threads.xml
@@ -3,8 +3,8 @@
     <VBox bkcolor="bk_wnd_darkcolor" visible="true">    
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label text="duilib 多线程使用示例程序" height="32" text_align="vcenter" margin="10,0,0,0"/>
-            <Control />
+            <Label text="duilib 多线程使用示例程序" height="32" text_align="vcenter" margin="10,0,0,0" mouse="false"/>
+            <Control mouse="false"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">
                 <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/bin/resources/themes/default/tree_view/tree_view.xml
+++ b/bin/resources/themes/default/tree_view/tree_view.xml
@@ -16,11 +16,11 @@
         <!-- 标题栏区域 -->  
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
             <!-- 标题栏：窗口左上角显示区域 -->  
-            <HBox margin="0,0,30,0" valign="center" width="auto" height="auto">
+            <HBox margin="0,0,30,0" valign="center" width="auto" height="auto" mouse="false">
                 <Control width="18" height="18" bkimage="public/caption/logo.svg" valign="center" margin="8,0,0,0"/>
-                <Label text="TreeView控件测试程序" valign="center" margin="8,0,0,0"/>
+                <Label text="TreeView控件测试程序" valign="center" margin="8,0,0,0" mouse="false"/>
             </HBox>
-            <Control />
+            <Control mouse="false"/>
             <!-- 标题栏：右侧窗口控制区域，窗口最小化、最大化、还原、关闭按钮 -->
             <HBox margin="0,0,0,0" valign="center" width="auto" height="36">
                 <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>

--- a/bin/resources/themes/default/virtual_list_box/main.xml
+++ b/bin/resources/themes/default/virtual_list_box/main.xml
@@ -3,8 +3,8 @@
     <VBox bkcolor="bk_wnd_darkcolor">
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label text="虚表（VirtualHTileListBox | VirtualVTileListBox | VirtualHListBox | VirtualVListBox）" font="system_14" valign="center" margin="8"/>
-            <Control />
+            <Label text="虚表（VirtualHTileListBox | VirtualVTileListBox | VirtualHListBox | VirtualVListBox）" font="system_14" valign="center" margin="8" mouse="false"/>
+            <Control mouse="false"/>
             <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
             <Box height="stretch" width="40" margin="0,2,0,2">
                 <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/bin/resources/themes/default/webview2/webview2.xml
+++ b/bin/resources/themes/default/webview2/webview2.xml
@@ -3,7 +3,7 @@
     <VBox bkcolor="bk_wnd_darkcolor">
         <!-- 标题栏区域 -->
         <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
-            <Label name="page_title" width="stretch" height="32" text_align="left,vcenter" text_padding="8,2,5,0"/>
+            <Label name="page_title" width="stretch" height="32" text_align="left,vcenter" text_padding="8,2,5,0" mouse="false"/>
             <Button name="btn_dev_tool" height="32" width="40" margin="0,2,4,2" valign="center" 
                           tooltip_text="开发者工具" bkimage="file='dev_tool.svg' height='20' width='20' halign='center' valign='center'"
                           hot_color="AliceBlue" pushed_color="Lavender"/>

--- a/bin/resources/themes/default/webview2_browser/webview2_browser.xml
+++ b/bin/resources/themes/default/webview2_browser/webview2_browser.xml
@@ -25,8 +25,8 @@
     		
             <!-- 标题栏区域 -->
             <HBox name="window_caption_bar" width="auto" height="36" bkcolor="">
-                <Control />
-                <Control width="36"/>
+                <Control mouse="false"/>
+                <Control width="36" mouse="false"/>
                 <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2" tooltip_text="最小化"/>
                 <Box height="stretch" width="40" margin="0,2,0,2">
                     <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn" tooltip_text="最大化"/>

--- a/docs/Control.md
+++ b/docs/Control.md
@@ -71,7 +71,7 @@
 | focus_rect_color | | string | SetFocusRectColor| 焦点状态矩形的颜色 |
 | alpha | 255 | int | SetAlpha|控件的整体透明度,如(128)，有效值为 0-255 |
 | state | normal | string | SetState|控件的当前状态: 支持normal、hot、pushed、disabled状态 |
-| cursor_type | arrow | string | SetCursorType|鼠标移动到控件上时的鼠标光标: <br>"arrow"：箭头<br>"hand"：手型<br>"wait"：忙碌<br>"cross"：精度选择<br>"ibeam"：“I”形状<br>"size_we"：左右拖动<br>"size_ns"：上下拖动<br>"size_nwse"：垂直调整大小<br>"size_nesw"：对角线调整大小<br>"size_all"：移动<br>"no"：不可用|
+| cursor_type | arrow | string | SetCursorType|鼠标移动到控件上时的鼠标光标: <br>"arrow"：箭头<br>"hand"：手型<br>"wait"：忙碌<br>"cross"：十字线<br>"ibeam"：I型光标,文本光标<br>"size_we"：水平调整<br>"size_ns"：垂直调整<br>"size_nwse"：对角线调整，西北-东南调整<br>"size_nesw"：对角线调整，东北-西南调整<br>"size_all"：移动，四向调整<br>"no"：禁止光标<br>"progress"：进度，应用启动光标|
 | render_offset | 0,0 | size | SetRenderOffset|控件绘制时的偏移量,如(10,10),一般用于绘制动画 |
 | fade_alpha | false | bool | GetAnimationManager(). SetFadeAlpha|是否启用控件透明渐变动画,如“true”|
 | fade_hot | false | bool |GetAnimationManager(). SetFadeHot |是否启用控件悬浮状态下 的透明渐变动画,如“true”|

--- a/duilib/CEFControl/CefControl.cpp
+++ b/duilib/CEFControl/CefControl.cpp
@@ -1129,6 +1129,10 @@ void CefControl::OnFocusedNodeChanged(CefRefPtr<CefBrowser> /*browser*/,
 {
 }
 
+void CefControl::OnCursorChange(cef_cursor_type_t /*type*/)
+{
+}
+
 Control* CefControl::GetCefControl()
 {
     return this;

--- a/duilib/CEFControl/CefControl.cpp
+++ b/duilib/CEFControl/CefControl.cpp
@@ -6,6 +6,7 @@
 #include "duilib/CEFControl/internal/CefJSBridge.h"
 #include "duilib/CEFControl/internal/CefBrowserHandler.h"
 #include "duilib/CEFControl/CefManager.h"
+#include <thread>
 
 namespace ui {
 
@@ -278,9 +279,24 @@ void CefControl::RepairBrowser()
 
 void CefControl::CloseAllBrowsers()
 {
+    DoCloseAllBrowsers();
+}
+
+void CefControl::DoCloseAllBrowsers()
+{
     if (m_pBrowserHandler != nullptr) {
         m_pBrowserHandler->CloseAllBrowsers();
     }
+}
+
+void CefControl::OnHostWindowClosed()
+{
+    CloseAllBrowsers();
+    if (m_pBrowserHandler != nullptr) {
+        m_pBrowserHandler->SetHostWindowClosed(true);
+    }
+    //释放一次CPU时间片，让CEF UI线程执行
+    std::this_thread::sleep_for(std::chrono::microseconds(1));
 }
 
 void CefControl::ResetDevToolAttachedState()

--- a/duilib/CEFControl/CefControl.h
+++ b/duilib/CEFControl/CefControl.h
@@ -569,6 +569,10 @@ protected:
                                       bool bEditable,
                                       const CefRect& nodeRect) override;
 
+    /** 设置光标(仅离屏渲染模式有效)
+    */
+    virtual void OnCursorChange(cef_cursor_type_t type) override;
+
     /** 获取关联的CEF控件接口
     */
     virtual Control* GetCefControl() override;

--- a/duilib/CEFControl/CefControl.h
+++ b/duilib/CEFControl/CefControl.h
@@ -135,6 +135,10 @@ public:
     */
     virtual std::shared_ptr<IBitmap> MakeImageSnapshot();
 
+    /** 关联窗口关闭事件
+    */
+    virtual void OnHostWindowClosed();
+
 public:
 
     /** 设置开发者工具关联的控件(设置后，开发者的内容就显示在这个控件中；如果为nullptr，则开发者工具显示为弹出式窗口)
@@ -401,6 +405,10 @@ protected:
     /** 重新创建Browser对象
     */
     virtual void ReCreateBrowser() = 0;
+
+    /** 关闭所有的Browser对象
+    */
+    void DoCloseAllBrowsers();
 
 protected:
     /** CefRenderHandler接口, 在非UI线程中被调用

--- a/duilib/CEFControl/CefControlNative.cpp
+++ b/duilib/CEFControl/CefControlNative.cpp
@@ -20,14 +20,10 @@ CefControlNative::CefControlNative(ui::Window* pWindow):
 
 CefControlNative::~CefControlNative(void)
 {
-    CefControlNative::CloseAllBrowsers();
-    if (m_pBrowserHandler.get() && m_pBrowserHandler->GetBrowser().get()) {
+    DoCloseAllNativeBrowsers();
+    if (m_pBrowserHandler.get()) {
         m_pBrowserHandler->SetHostWindow(nullptr);
         m_pBrowserHandler->SetHandlerDelegate(nullptr);
-        // Request that the main browser close.
-        if (m_pBrowserHandler->GetBrowserHost() != nullptr) {
-            m_pBrowserHandler->GetBrowserHost()->CloseBrowser(true);
-        }        
     }
 }
 
@@ -161,7 +157,7 @@ void CefControlNative::UpdateCefWindowPos()
     SetVisible(IsVisible());
 }
 
-void CefControlNative::CloseAllBrowsers()
+void CefControlNative::DoCloseAllNativeBrowsers()
 {
 #ifdef DUILIB_BUILD_FOR_WIN
     //关闭窗口时，取消父子关系，避免导致退出时的崩溃问题
@@ -171,6 +167,11 @@ void CefControlNative::CloseAllBrowsers()
     }
 #endif
     BaseClass::CloseAllBrowsers();
+}
+
+void CefControlNative::CloseAllBrowsers()
+{
+    DoCloseAllNativeBrowsers();
 }
 
 void CefControlNative::SetWindow(ui::Window* pWindow)

--- a/duilib/CEFControl/CefControlNative.h
+++ b/duilib/CEFControl/CefControlNative.h
@@ -63,6 +63,10 @@ private:
     bool CaptureWindowBitmap_X11(std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height);
 #endif
 
+    /** 关闭所有的Browser对象
+    */
+    void DoCloseAllNativeBrowsers();
+
 private:
     /** 首次绘制的事件是否关联
     */

--- a/duilib/CEFControl/CefControlNative.h
+++ b/duilib/CEFControl/CefControlNative.h
@@ -53,16 +53,6 @@ protected:
     virtual std::shared_ptr<IBitmap> MakeImageSnapshot() override;
 
 private:
-    /** 将页面保存为成一张位图数据
-    */
-#if defined (DUILIB_BUILD_FOR_WIN)
-    bool CaptureWindowBitmap_Win32(std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height);
-#elif defined (DUILIB_BUILD_FOR_MACOS)
-    bool CaptureWindowBitmap_Mac(std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height);
-#elif defined (DUILIB_BUILD_FOR_LINUX) || defined (DUILIB_BUILD_FOR_FREEBSD)
-    bool CaptureWindowBitmap_X11(std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height);
-#endif
-
     /** 关闭所有的Browser对象
     */
     void DoCloseAllNativeBrowsers();

--- a/duilib/CEFControl/CefControlOffScreen.h
+++ b/duilib/CEFControl/CefControlOffScreen.h
@@ -63,6 +63,10 @@ protected:
                                       bool bEditable,
                                       const CefRect& nodeRect) override;
 
+    /** 设置光标(仅离屏渲染模式有效)
+    */
+    virtual void OnCursorChange(cef_cursor_type_t type) override;
+
     //光标消息
     virtual bool OnSetCursor(const EventArgs& msg) override;
 

--- a/duilib/CEFControl/CefManager.h
+++ b/duilib/CEFControl/CefManager.h
@@ -204,6 +204,10 @@ private:
     */
     int32_t m_nCefDoMessageLoopWorkDelayMs;
 
+    /** 退出时的编码
+    */
+    int32_t m_nExitCode;
+
     /** 是否设置了CEF的网页缓存目录
     */
     bool m_bHasCefCachePath;
@@ -215,6 +219,10 @@ private:
     /** 是否已经初始化
     */
     bool m_bCefInit;
+
+    /** CEF消息队列是否为空
+    */
+    bool m_bCefMessageLoopEmpty;
 };
 
 } //namespace ui

--- a/duilib/CEFControl/CefWindowUtils.h
+++ b/duilib/CEFControl/CefWindowUtils.h
@@ -22,6 +22,10 @@ void SetCefWindowParent(CefWindowHandle cefWindow, CefControl* pCefControl);
 */
 bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height);
 
+/** 设置光标
+*/
+void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor);
+
 } //namespace ui
 
 #endif //UI_CEF_CONTROL_CEF_WINDOW_UTILS_H_

--- a/duilib/CEFControl/CefWindowUtils.h
+++ b/duilib/CEFControl/CefWindowUtils.h
@@ -2,6 +2,7 @@
 #define UI_CEF_CONTROL_CEF_WINDOW_UTILS_H_
 
 #include "CefControl.h"
+#include <vector>
 
 namespace ui
 {
@@ -16,6 +17,10 @@ void SetCefWindowVisible(CefWindowHandle cefWindow, CefControl* pCefControl);
 /** 设置CEF关联的窗口的父窗口(父窗口为pCefControl的关联窗口)
 */
 void SetCefWindowParent(CefWindowHandle cefWindow, CefControl* pCefControl);
+
+/** 抓取CEF窗口的截图为位图数据
+*/
+bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height);
 
 } //namespace ui
 

--- a/duilib/CEFControl/CefWindowUtils_Linux.cpp
+++ b/duilib/CEFControl/CefWindowUtils_Linux.cpp
@@ -250,6 +250,24 @@ bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bit
     return true;
 }
 
+void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor)
+{
+    if ((cefWindow == 0) || (cursor == 0)) {
+        return;
+    }
+    Display* display = ::XOpenDisplay(nullptr);
+    if (display != nullptr) {
+        // RAII资源管理
+        struct DisplayCloser {
+            Display* d;
+            ~DisplayCloser() { if (d) ::XCloseDisplay(d); }
+        } closer{ display };
+
+        ::Window x11Window = cefWindow;
+        XDefineCursor(display, x11Window, cursor);
+    }
+}
+
 } //namespace ui
 
 #endif //defined (DUILIB_BUILD_FOR_LINUX) || defined (DUILIB_BUILD_FOR_FREEBSD)

--- a/duilib/CEFControl/CefWindowUtils_Linux.cpp
+++ b/duilib/CEFControl/CefWindowUtils_Linux.cpp
@@ -1,11 +1,12 @@
 #include "CefWindowUtils.h"
 #include "duilib/Core/Window.h"
 
-#ifdef DUILIB_BUILD_FOR_LINUX
-//Linux OS
+#if defined (DUILIB_BUILD_FOR_LINUX) || defined (DUILIB_BUILD_FOR_FREEBSD)
+//Linux/FreeBSD OS
 
 #include "include/cef_task.h"
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 
 namespace ui
 {
@@ -162,6 +163,93 @@ void SetCefWindowParent(CefWindowHandle cefWindow, CefControl* pCefControl)
     CefPostTask(TID_UI, new SetX11WindowParentWindowTask(pCefControl));
 }
 
+bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height)
+{
+    // 检查X11环境更加健壮
+    const char* sessionType = std::getenv("XDG_SESSION_TYPE");
+    if (!sessionType || (std::string(sessionType) != "x11" && std::string(sessionType) != "X11")) {
+        // 尝试使用DISPLAY环境变量进行二次检查
+        const char* displayEnv = std::getenv("DISPLAY");
+        if (!displayEnv || !*displayEnv) {
+            return false;
+        }
+    }
+
+    Display* display = ::XOpenDisplay(nullptr);
+    if (!display) {
+        return false;
+    }
+
+    // RAII资源管理
+    struct DisplayCloser {
+        Display* d;
+        ~DisplayCloser() { if (d) ::XCloseDisplay(d); }
+    } closer{ display };
+
+    ::Window x11Window = cefWindow;
+
+    // 获取窗口尺寸
+    ::XWindowAttributes gwa;
+    if (!::XGetWindowAttributes(display, x11Window, &gwa)) {
+        return false;
+    }
+    width = gwa.width;
+    height = gwa.height;
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    // 获取窗口内容
+    XImage* image = XGetImage(display, x11Window, 0, 0, width, height, AllPlanes, ZPixmap);
+    if (!image) {
+        return false;
+    }
+
+    // RAII管理XImage资源
+    struct ImageDestroyer {
+        XImage* img;
+        ~ImageDestroyer() { if (img) XDestroyImage(img); }
+    } imgDestroyer{ image };
+
+    // 分配内存并复制像素数据
+    bitmap.resize(width * height * 4);
+
+    // 使用更安全的像素格式转换
+    bool isRgbOrder = (image->red_mask == 0xFF0000);
+    bool isBgrOrder = (image->blue_mask == 0xFF0000);
+
+    // 使用XGetPixel作为安全的像素获取方式
+    for (int y = 0; y < height; y++) {
+        for (int x = 0; x < width; x++) {
+            unsigned long pixel = XGetPixel(image, x, y);
+            unsigned char r, g, b;
+
+            if (isRgbOrder) {
+                r = (pixel >> 16) & 0xFF;
+                g = (pixel >> 8) & 0xFF;
+                b = pixel & 0xFF;
+            }
+            else if (isBgrOrder) {
+                r = pixel & 0xFF;
+                g = (pixel >> 8) & 0xFF;
+                b = (pixel >> 16) & 0xFF;
+            }
+            else {
+                // 无法确定顺序，使用灰度
+                r = g = b = (pixel * 255) / ((1 << image->bits_per_pixel) - 1);
+            }
+
+            int index = (y * width + x) * 4;
+            bitmap[index] = r;
+            bitmap[index + 1] = g;
+            bitmap[index + 2] = b;
+            bitmap[index + 3] = 255;
+        }
+    }
+
+    return true;
+}
+
 } //namespace ui
 
-#endif //DUILIB_BUILD_FOR_LINUX
+#endif //defined (DUILIB_BUILD_FOR_LINUX) || defined (DUILIB_BUILD_FOR_FREEBSD)

--- a/duilib/CEFControl/CefWindowUtils_MacOS.mm
+++ b/duilib/CEFControl/CefWindowUtils_MacOS.mm
@@ -186,6 +186,27 @@ bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bit
     return true;
 }
 
+void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor)
+{
+    if ((cefWindow == nullptr) || (cursor == nullptr)) {
+        return;
+    }
+    // 将 CEF 窗口句柄转换为 NSView*
+    NSView* cefView = static_cast<NSView*>(cefWindow);
+    // 将 CEF 光标句柄转换为 NSCursor*
+    NSCursor* nsCursor = static_cast<NSCursor*>(cursor);
+    
+    // 确保在主线程操作 UI 元素（Cocoa UI 操作需要在主线程执行）
+    if ([NSThread isMainThread]) {
+        [cefView setCursor:nsCursor];
+    } else {
+        // 如果不在主线程，调度到主线程执行
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [cefView setCursor:nsCursor];
+        });
+    }
+}
+
 } //namespace ui
 
 #endif //DUILIB_BUILD_FOR_MACOS

--- a/duilib/CEFControl/CefWindowUtils_MacOS.mm
+++ b/duilib/CEFControl/CefWindowUtils_MacOS.mm
@@ -191,19 +191,28 @@ void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor)
     if ((cefWindow == nullptr) || (cursor == nullptr)) {
         return;
     }
+    
     // 将 CEF 窗口句柄转换为 NSView*
     NSView* cefView = static_cast<NSView*>(cefWindow);
     // 将 CEF 光标句柄转换为 NSCursor*
     NSCursor* nsCursor = static_cast<NSCursor*>(cursor);
     
-    // 确保在主线程操作 UI 元素（Cocoa UI 操作需要在主线程执行）
+    // 获取视图所在的窗口
+    NSWindow* window = [cefView window];
+    if (!window) {
+        return;
+    }
+    
+    // 确保在主线程操作 UI 元素
+    auto setCursorBlock = ^{        
+        // 对于视图范围的光标，可以使用 NSCursor 的 set 方法
+         [nsCursor set];
+    };
+    
     if ([NSThread isMainThread]) {
-        [cefView setCursor:nsCursor];
+        setCursorBlock();
     } else {
-        // 如果不在主线程，调度到主线程执行
-        dispatch_sync(dispatch_get_main_queue(), ^{
-            [cefView setCursor:nsCursor];
-        });
+        dispatch_sync(dispatch_get_main_queue(), setCursorBlock);
     }
 }
 

--- a/duilib/CEFControl/CefWindowUtils_Windows.cpp
+++ b/duilib/CEFControl/CefWindowUtils_Windows.cpp
@@ -143,6 +143,15 @@ bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bit
     return true;
 }
 
+void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor)
+{
+    if ((cefWindow == nullptr) || (cursor == nullptr)) {
+        return;
+    }
+    ::SetClassLongPtr((HWND)cefWindow, GCLP_HCURSOR, static_cast<LONG>(reinterpret_cast<LONG_PTR>(cursor)));
+    ::SetCursor(cursor);
+}
+
 } //namespace ui
 
 #endif //DUILIB_BUILD_FOR_WIN

--- a/duilib/CEFControl/CefWindowUtils_Windows.cpp
+++ b/duilib/CEFControl/CefWindowUtils_Windows.cpp
@@ -64,6 +64,85 @@ void SetCefWindowParent(CefWindowHandle cefWindow, CefControl* pCefControl)
     ::SetWindowLong(hParent, GWL_STYLE, style | WS_CLIPSIBLINGS | WS_CLIPCHILDREN);
 }
 
+bool CaptureCefWindowBitmap(CefWindowHandle cefWindow, std::vector<uint8_t>& bitmap, int32_t& width, int32_t& height)
+{
+    HWND hwnd = cefWindow;
+    if (!::IsWindow(hwnd)) {
+        return false;
+    }
+    // 获取窗口尺寸
+    RECT rect = { 0, 0, 0, 0 };
+    if (!GetClientRect(hwnd, &rect)) {
+        return false;
+    }
+
+    width = rect.right - rect.left;
+    height = rect.bottom - rect.top;
+
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    // 创建设备上下文
+    HDC hdcScreen = ::GetDC(nullptr);
+    if (hdcScreen == nullptr) {
+        return false;
+    }
+    HDC hdcWindow = ::GetDC(hwnd);
+    if (hdcWindow == nullptr) {
+        ::ReleaseDC(nullptr, hdcScreen);
+        return false;
+    }
+
+    HDC hdcMemDC = ::CreateCompatibleDC(hdcWindow);
+    if (hdcMemDC == nullptr) {
+        ::ReleaseDC(nullptr, hdcScreen);
+        ::ReleaseDC(hwnd, hdcWindow);
+        return false;
+    }
+
+    // 创建位图
+    HBITMAP hBitmap = ::CreateCompatibleBitmap(hdcWindow, width, height);
+    if (hBitmap == nullptr) {
+        ::DeleteDC(hdcMemDC);
+        ::ReleaseDC(nullptr, hdcScreen);
+        ::ReleaseDC(hwnd, hdcWindow);
+        return false;
+    }
+
+    HGDIOBJ hOldObj = ::SelectObject(hdcMemDC, hBitmap);
+
+    // 拷贝屏幕内容到位图
+    ::BitBlt(hdcMemDC, 0, 0, width, height, hdcWindow, 0, 0, SRCCOPY);
+
+    // 获取位图信息
+    BITMAPINFOHEADER bi;
+    bi.biSize = sizeof(BITMAPINFOHEADER);
+    bi.biWidth = width;
+    bi.biHeight = -height;  // 正数表示从下到上，负数表示从上到下
+    bi.biPlanes = 1;
+    bi.biBitCount = 32;
+    bi.biCompression = BI_RGB;
+    bi.biSizeImage = 0;
+    bi.biXPelsPerMeter = 0;
+    bi.biYPelsPerMeter = 0;
+    bi.biClrUsed = 0;
+    bi.biClrImportant = 0;
+
+    // 分配内存并获取位图数据
+    bitmap.resize(width * height * 4);
+    ::GetDIBits(hdcMemDC, hBitmap, 0, height, bitmap.data(), (BITMAPINFO*)&bi, DIB_RGB_COLORS);
+
+    // 清理资源
+    ::SelectObject(hdcMemDC, hOldObj);
+    ::DeleteObject(hBitmap);
+    ::DeleteDC(hdcMemDC);
+    ::ReleaseDC(nullptr, hdcScreen);
+    ::ReleaseDC(hwnd, hdcWindow);
+
+    return true;
+}
+
 } //namespace ui
 
 #endif //DUILIB_BUILD_FOR_WIN

--- a/duilib/CEFControl/CefWindowUtils_Windows.cpp
+++ b/duilib/CEFControl/CefWindowUtils_Windows.cpp
@@ -148,7 +148,7 @@ void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor)
     if ((cefWindow == nullptr) || (cursor == nullptr)) {
         return;
     }
-    ::SetClassLongPtr((HWND)cefWindow, GCLP_HCURSOR, static_cast<LONG>(reinterpret_cast<LONG_PTR>(cursor)));
+    ::SetClassLongPtr((HWND)cefWindow, GCLP_HCURSOR, reinterpret_cast<LONG_PTR>(cursor));
     ::SetCursor(cursor);
 }
 

--- a/duilib/CEFControl/internal/CefBrowserHandler.cpp
+++ b/duilib/CEFControl/internal/CefBrowserHandler.cpp
@@ -518,7 +518,7 @@ bool CefBrowserHandler::GetScreenPoint(CefRefPtr<CefBrowser> browser, int viewX,
 #if defined (DUILIB_BUILD_FOR_MACOS)
     //MacOS: 屏幕坐标是以屏幕左下角为原点的，需要进行转换
     UiRect rcMonitor;
-    m_pWindow->GetMonitorRect(rcMonitor);
+    spWindow->GetMonitorRect(rcMonitor);
     screenY = rcMonitor.Height() - screenY;
 #endif
     return true;

--- a/duilib/CEFControl/internal/CefBrowserHandler.cpp
+++ b/duilib/CEFControl/internal/CefBrowserHandler.cpp
@@ -177,6 +177,9 @@ bool CefBrowserHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
     }
     // 处理render进程发来的消息
     std::string message_name = message->GetName();
+    if (message->GetArgumentList() == nullptr) {
+        return false;
+    }
     if (message_name == kFocusedNodeChangedMessage) {
         CefDOMNode::Type type = (CefDOMNode::Type)message->GetArgumentList()->GetInt(0);
         bool bText = message->GetArgumentList()->GetBool(1);
@@ -188,7 +191,7 @@ bool CefBrowserHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
         nodeRect.width = message->GetArgumentList()->GetInt(5);
         nodeRect.height = message->GetArgumentList()->GetInt(6);
 
-        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, ToWeakCallback([=]() {
+        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, ToWeakCallback([this, browser, frame, type, bText, bEditable, nodeRect]() {
                 if (m_pHandlerDelegate) {
                     m_pHandlerDelegate->OnFocusedNodeChanged(browser, frame, type, bText, bEditable, nodeRect);
                 }
@@ -196,11 +199,11 @@ bool CefBrowserHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
         return true;
     }
     else if (message_name == kCallCppFunctionMessage) {
-        CefString fun_name    = message->GetArgumentList()->GetString(0);
-        CefString param        = message->GetArgumentList()->GetString(1);
-        int js_callback_id    = message->GetArgumentList()->GetInt(2);
+        CefString fun_name = message->GetArgumentList()->GetString(0);
+        CefString param = message->GetArgumentList()->GetString(1);
+        int js_callback_id = message->GetArgumentList()->GetInt(2);
 
-        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, ToWeakCallback([=]() {
+        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, ToWeakCallback([this, fun_name, param, js_callback_id, browser, frame]() {
                 if (m_pHandlerDelegate) {
                     m_pHandlerDelegate->OnExecuteCppFunc(fun_name, param, js_callback_id, browser, frame);
                 }
@@ -211,7 +214,7 @@ bool CefBrowserHandler::OnProcessMessageReceived(CefRefPtr<CefBrowser> browser,
         CefString param = message->GetArgumentList()->GetString(0);
         int callback_id = message->GetArgumentList()->GetInt(1);
 
-        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, ToWeakCallback([=]() {
+        GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, ToWeakCallback([this, callback_id, param]() {
             if (m_pHandlerDelegate) {
                 m_pHandlerDelegate->OnExecuteCppCallbackFunc(callback_id, param);
             }

--- a/duilib/CEFControl/internal/CefBrowserHandler.cpp
+++ b/duilib/CEFControl/internal/CefBrowserHandler.cpp
@@ -895,6 +895,12 @@ bool CefBrowserHandler::OnCursorChange(CefRefPtr<CefBrowser> browser,
     else {
         //离屏渲染模式：需要设置光标
         SetCefWindowCursor(GetCefWindowHandle(), cursor);
+#ifdef DUILIB_BUILD_FOR_SDL
+        //由于SDL内部，未开放设置光标事件，所以需要主动设置SDL的光标，才能保证光标正确（SDL内部会设置光标，覆盖此处的光标）
+        if (m_pHandlerDelegate && !m_bHostWindowClosed) {
+            GlobalManager::Instance().Thread().PostTask(ui::kThreadUI, UiBind(&CefBrowserHandlerDelegate::OnCursorChange, m_pHandlerDelegate, type));
+        }
+#endif
         return true;
     }
 }

--- a/duilib/CEFControl/internal/CefBrowserHandler.h
+++ b/duilib/CEFControl/internal/CefBrowserHandler.h
@@ -19,7 +19,9 @@
 #pragma warning (pop)
 
 #include "duilib/Core/Window.h"
+#include "duilib/Core/ControlPtrT.h"
 #include <mutex>
+#include <atomic>
 
 namespace ui
 {
@@ -66,6 +68,7 @@ public:
 
     // 设置Cef渲染内容的大小
     void SetViewRect(const UiRect& rc);
+    UiRect GetViewRect();
 
     CefRefPtr<CefBrowser> GetBrowser(){ return m_browser; }
 
@@ -79,6 +82,11 @@ public:
      /** 关闭所有的Browser对象
      */
      void CloseAllBrowsers();
+
+     /** 设置关联窗口是否已经关闭
+     */
+     void SetHostWindowClosed(bool bHostWindowClosed);
+
 public:
     
     // CefClient的接口实现
@@ -430,18 +438,20 @@ private:
 private:
     /** 数据多线程同步锁
     */
-    std::mutex m_rectMutex;
+    std::mutex m_dataMutex;
 
     CefRefPtr<CefBrowser> m_browser;
     CefWindowHandle m_hCefWindowHandle;
     std::vector<CefRefPtr<CefBrowser>> m_browserList;
-    ui::Window* m_pWindow;
-    std::weak_ptr<ui::WeakFlag> m_windowFlag;    
+    ControlPtrT<ui::Window> m_spWindow; 
     CefBrowserHandlerDelegate* m_pHandlerDelegate;
     //控件的位置
     UiRect m_rcCefControl;
     CefUnregistedCallbackList<ui::StdClosure> m_taskListAfterCreated;
     CefRenderHandler::DragOperation m_currentDragOperation;
+
+    //关联窗口是否已经关闭
+    std::atomic<bool> m_bHostWindowClosed;
 
 #ifdef DUILIB_BUILD_FOR_WIN
     std::shared_ptr<CefOsrDropTarget> m_pDropTarget;

--- a/duilib/CEFControl/internal/CefBrowserHandlerDelegate.h
+++ b/duilib/CEFControl/internal/CefBrowserHandlerDelegate.h
@@ -184,6 +184,10 @@ public:
                                       bool bEditable,
                                       const CefRect& nodeRect) = 0;
 
+    /** 设置光标(仅离屏渲染模式有效，仅使用SDL时有效)
+    */
+    virtual void OnCursorChange(cef_cursor_type_t type) = 0;
+
     /** 获取关联的CEF控件接口
     */
     virtual Control* GetCefControl() = 0;

--- a/duilib/CEFControl/internal/CefMemoryBlock.cpp
+++ b/duilib/CEFControl/internal/CefMemoryBlock.cpp
@@ -78,16 +78,18 @@ void CefMemoryBlock::Clear()
     m_nHeight = 0;
 }
 
-void CefMemoryBlock::PaintData(IRender* pRender, const UiRect& rcPaint, int32_t left, int32_t top)
+void CefMemoryBlock::PaintData(IRender* pRender,const UiRect& rc)
 {
+    ASSERT(rc.Width() == GetWidth());
+    ASSERT(rc.Height() == GetHeight());
     std::lock_guard<std::mutex> threadGuard(m_memMutex);
     //通过直接写入数据的接口，性能最佳
     UiRect dcPaint;
-    dcPaint.left = left;
-    dcPaint.top = top;
+    dcPaint.left = rc.left;
+    dcPaint.top = rc.top;
     dcPaint.right = dcPaint.left + GetWidth();
     dcPaint.bottom = dcPaint.top + GetHeight();
-    if (!dcPaint.IsEmpty() && !rcPaint.IsEmpty() && IsValid()) {
+    if (!dcPaint.IsEmpty() && IsValid()) {
         bool bRet = pRender->WritePixels(GetBits(), GetWidth() * GetHeight() * sizeof(uint32_t), dcPaint);
         ASSERT_UNUSED_VARIABLE(bRet);
     }

--- a/duilib/CEFControl/internal/CefMemoryBlock.h
+++ b/duilib/CEFControl/internal/CefMemoryBlock.h
@@ -24,7 +24,7 @@ public:
 
     /** 将位图数据绘制到Render
     */
-    void PaintData(IRender* pRender, const UiRect& rcPaint, int32_t left, int32_t top);
+    void PaintData(IRender* pRender, const UiRect& rc);
 
     /** 判断内存块是否可以使用
     */
@@ -34,6 +34,14 @@ public:
     */
     bool MakeImageSnapshot(IRender* pRender);
 
+    /** 获取内存位图的宽度
+    */
+    int32_t GetWidth() const;
+
+    /** 获取内存位图的高度
+    */
+    int32_t GetHeight() const;
+
 private:
     /** 删除位图数据并初始化变量
     */
@@ -42,14 +50,6 @@ private:
     /** 获取内存位图数据指针，可用于填充位图数据
     */
     uint8_t* GetBits() const;
-
-    /** 获取内存位图的宽度
-    */
-    int32_t GetWidth() const;
-
-    /** 获取内存位图的高度
-    */
-    int32_t GetHeight() const;
 
 private:
     /** 内存数据

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -3470,6 +3470,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
     bool bRet = true;//当值为false时，就不再调用回调函数和处理函数
 
     if (msg.GetSender() == this) {
+        //备注：EventMap 和 XmlEventMap里面的回调函数，需要校验消息的发送者是否为控件自身
         if (bRet && HasAttachEventMap() && !GetAttachEventMap().empty()) {
             const EventMap& attachEventMap = GetAttachEventMap();
             auto callback = attachEventMap.find(msg.eventType);
@@ -3509,6 +3510,7 @@ bool Control::FireAllEvents(const EventArgs& msg)
         }
     }
 
+    //备注：BubbledEventMap 和 XmlBubbledEventMap里面的回调函数，不需要校验消息的发送者是否为控件自身
     if (bRet && HasBubbledEventMap() && !GetBubbledEventMap().empty()) {
         const EventMap& bubbledEventMap = GetBubbledEventMap();
         auto callback = bubbledEventMap.find(msg.eventType);

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -261,6 +261,9 @@ void Control::SetAttribute(const DString& strName, const DString& strValue)
         else if (strValue == _T("no")) {
             SetCursorType(CursorType::kCursorNo);
         }
+        else if (strValue == _T("progress")) {
+            SetCursorType(CursorType::kCursorProgress);
+        }
         else {
             ASSERT(0);
         }

--- a/duilib/Core/CursorManager_SDL.cpp
+++ b/duilib/Core/CursorManager_SDL.cpp
@@ -104,7 +104,10 @@ bool CursorManager::SetCursor(CursorType cursorType)
         break;    
     case CursorType::kCursorNo:
         sdlCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NOT_ALLOWED);
-        break;    
+        break;
+    case CursorType::kCursorProgress:
+        sdlCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_PROGRESS);
+        break;
     default:
         break;
     }

--- a/duilib/Core/CursorManager_Windows.cpp
+++ b/duilib/Core/CursorManager_Windows.cpp
@@ -83,7 +83,10 @@ bool CursorManager::SetCursor(CursorType cursorType)
         break;    
     case CursorType::kCursorNo:
         ::SetCursor(::LoadCursor(nullptr, IDC_NO));
-        break;    
+        break;
+    case CursorType::kCursorProgress:
+        ::SetCursor(::LoadCursor(nullptr, IDC_APPSTARTING));
+        break;
     default:
         bRet = false;
         break;

--- a/duilib/Core/NativeWindow_SDL.cpp
+++ b/duilib/Core/NativeWindow_SDL.cpp
@@ -1312,14 +1312,19 @@ void NativeWindow_SDL::InitNativeWindow()
 
 void NativeWindow_SDL::ClearNativeWindow()
 {
-    if (m_sdlWindow != nullptr) {    
-        SDL_SetWindowHitTest(m_sdlWindow, nullptr, nullptr);
-        SDL_DestroyWindow(m_sdlWindow);
-        m_sdlWindow = nullptr;
+    SDL_Renderer* sdlRenderer = m_sdlRenderer;
+    SDL_Window* sdlWindow = m_sdlWindow;
+    m_sdlRenderer = nullptr;
+    m_sdlWindow = nullptr;
+
+    if (sdlWindow != nullptr) {
+        SDL_SetWindowHitTest(sdlWindow, nullptr, nullptr);
+        SDL_DestroyWindow(sdlWindow);
+        sdlWindow = nullptr;
     }
-    if (m_sdlRenderer != nullptr) {
-        SDL_DestroyRenderer(m_sdlRenderer);
-        m_sdlRenderer = nullptr;
+    if (sdlRenderer != nullptr) {
+        SDL_DestroyRenderer(sdlRenderer);
+        sdlRenderer = nullptr;
     }
 }
 

--- a/duilib/Core/Shadow.cpp
+++ b/duilib/Core/Shadow.cpp
@@ -230,6 +230,8 @@ Box* Shadow::AttachShadow(Box* pRoot)
     }
 
     m_pRoot = new ShadowBox(pRoot->GetWindow(), this);
+    m_pRoot->SetMouseEnabled(false);
+    m_pRoot->SetKeyboardEnabled(false);
     m_pRoot->AddItem(pRoot);
     DoAttachShadow(m_pRoot, pRoot, true, m_isMaximized);
     return m_pRoot;

--- a/duilib/RenderSkia/Render_Skia.cpp
+++ b/duilib/RenderSkia/Render_Skia.cpp
@@ -2106,8 +2106,6 @@ void Render_Skia::DrawRichTextCacheData(const std::shared_ptr<DrawRichTextCache>
         return;
     }
 
-    const UiRect& rcTextRect = spDrawRichTextCache->m_textRect;
-
     const SkTextEncoding textEncoding = spDrawRichTextCache->m_textEncoding;
     const size_t textCharSize = spDrawRichTextCache->m_textCharSize;
 
@@ -2151,7 +2149,7 @@ void Render_Skia::DrawRichTextCacheData(const std::shared_ptr<DrawRichTextCache>
             textRects.push_back(rcDestRect);
         }
 
-        if (!UiRect::Intersect(rcTemp, rcDestRect, rcTextRect)) {
+        if (!UiRect::Intersect(rcTemp, rcDestRect, rcNewTextRect)) {
             continue;
         }
 

--- a/duilib/Utils/WinImplBase.cpp
+++ b/duilib/Utils/WinImplBase.cpp
@@ -64,6 +64,14 @@ void WindowImplBase::PreInitWindow()
             ASSERT(pControl->GetType() == DUI_CTR_BUTTON);
             pControl->AttachClick(UiBind(&WindowImplBase::OnButtonClick, this, std::placeholders::_1));
         }
+
+#if defined (DUILIB_BUILD_FOR_SDL) && !defined (DUILIB_BUILD_FOR_WIN)
+        //标题栏: 由于使用SDL时，不支持双击标题栏最大化/还原窗口，所以自己实现此逻辑（非Windows平台）
+        pControl = FindControl(DUI_CTR_CAPTION_BAR);
+        if (pControl) {
+            pControl->AttachBubbledEvent(ui::kEventMouseDoubleClick, UiBind(&WindowImplBase::OnTitleBarDoubleClick, this, std::placeholders::_1));
+        }
+#endif
     }
 }
 
@@ -134,6 +142,27 @@ bool WindowImplBase::OnButtonClick(const EventArgs& msg)
         EnterFullScreen();
     }
 
+    return true;
+}
+
+bool WindowImplBase::OnTitleBarDoubleClick(const EventArgs& /*param*/)
+{
+    Control* pControl = FindControl(DUI_CTR_BUTTON_MAX);
+    if ((pControl != nullptr) && pControl->IsVisible()) {
+        //最大化按钮
+        if (!IsWindowMaximized()) {
+            ShowWindow(kSW_SHOW_MAXIMIZED);
+        }
+    }
+    else {
+        //还原按钮
+        pControl = FindControl(DUI_CTR_BUTTON_RESTORE);
+        if ((pControl != nullptr) && pControl->IsVisible()) {
+            if (IsWindowMaximized()) {
+                ShowWindow(kSW_RESTORE);
+            }            
+        }
+    }
     return true;
 }
 

--- a/duilib/Utils/WinImplBase.h
+++ b/duilib/Utils/WinImplBase.h
@@ -123,6 +123,12 @@ private:
     */
     bool OnButtonClick(const EventArgs& param);
 
+    /** 标题栏被双击时调用
+    * @param [in] param 携带的参数
+    * @return 始终返回 true
+    */
+    bool OnTitleBarDoubleClick(const EventArgs& param);
+
     /** 处理最大化/还原按钮的状态
     */
     void ProcessMaxRestoreStatus();

--- a/duilib/duilib_defs.h
+++ b/duilib/duilib_defs.h
@@ -227,13 +227,14 @@ namespace ui
         kCursorIBeam    = 1,    // “I”形状, 文本选择, XML文件中的名字："ibeam"
         kCursorHand     = 2,    // 手型, 链接选择, XML文件中的名字："hand"
         kCursorWait     = 3,    // 忙碌, XML文件中的名字："wait"
-        kCursorCross    = 4,    // 精度选择, XML文件中的名字："cross"
-        kCursorSizeWE   = 5,    // 水平调整大小, XML文件中的名字："size_we"
-        kCursorSizeNS   = 6,    // 垂直调整大小, XML文件中的名字："size_ns"
-        kCursorSizeNWSE = 7,    // 对角线调整大小 1, XML文件中的名字："size_nwse"
-        kCursorSizeNESW = 8,    // 对角线调整大小 2, XML文件中的名字： "size_nesw"
-        kCursorSizeAll  = 9,    // 移动, XML文件中的名字："size_all"
-        kCursorNo       = 10    // 不可用, XML文件中的名字："no"
+        kCursorCross    = 4,    // 十字线, XML文件中的名字："cross"
+        kCursorSizeWE   = 5,    // 水平调整, XML文件中的名字："size_we"
+        kCursorSizeNS   = 6,    // 垂直调整, XML文件中的名字："size_ns"
+        kCursorSizeNWSE = 7,    // 对角线调整，西北-东南调整 1, XML文件中的名字："size_nwse"
+        kCursorSizeNESW = 8,    // 对角线调整，东北-西南调整 2, XML文件中的名字： "size_nesw"
+        kCursorSizeAll  = 9,    // 移动，四向调整, XML文件中的名字："size_all"
+        kCursorNo       = 10,   // 禁止光标, XML文件中的名字："no"
+        kCursorProgress = 11    // 进度，应用启动光标, XML文件中的名字："progress"
     };
 
     //窗口退出参数


### PR DESCRIPTION
1. CEF控件离屏渲染模式的光标支持：（1）设置页面光标的代码，统一放在平台相关的类中实现（2）当使用SDL时，离屏渲染模式下支持页面的光标设置
2. CEF控件子窗口模式：拖出标签和拖入标签抓图功能的代码结构调整，统一放到平台相关的文件中。
3. CEF控件修复两个问题：（1）关闭窗口时偶发的崩溃问题；（2）窗口从最大化还原后，页面绘制内容（仅当为离屏渲染时）覆盖窗口阴影等其他区域的问题。(修复MacOS平台的编译错误问题)
4. CEF控件修复两个问题：（1）关闭窗口时偶发的崩溃问题；（2）窗口从最大化还原后，页面绘制内容（仅当为离屏渲染时）覆盖窗口阴影等其他区域的问题。
5. 自绘标题栏的功能完善：非Windows平台，支持双击标题栏来控制窗口最大化/还原（SDL3在非Windows平台，目前还不支持这个功能，修改后macOS支持，但Linux等其他平台仍不支持，主要受限于SDL内部实现）。
6. 修复Render_Skia::DrawRichTextCacheData中的一处代码逻辑错误：现象是RichEdit示例程序最大化以后，左侧的RichEdit控件都不绘制了。