### PR TITLE
解决DUTF32Char和DUTF16Char在各个平台的兼容性问题。

### DIFF
--- a/bin/resources/themes/default/global.xml
+++ b/bin/resources/themes/default/global.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Global>
     <!--默认字体名称，列表形式，依次匹配，直到发现第一个有效字体作为默认字体名称，多个字体名称用逗号分隔-->
-    <DefaultFontFamilyNames value="微软雅黑,宋体,PingFang SC"/>
+    <!-- 字体说明："微软雅黑","宋体" 是Windows使用 -->
+    <!-- 字体说明："PingFang SC" 是MacOS使用 -->
+    <!-- 字体说明："Noto Sans CJK SC" 是中科方德系统使用 -->
+    <DefaultFontFamilyNames value="微软雅黑,宋体,PingFang SC,Noto Sans CJK SC"/>
     
     <!--所有字体：默认为五号字-->
     <Font id="system_12" name="system" size="12"/>

--- a/duilib/CEFControl/CefControlOffScreen.cpp
+++ b/duilib/CEFControl/CefControlOffScreen.cpp
@@ -147,7 +147,7 @@ void CefControlOffScreen::ReCreateBrowser()
         // Don't activate the browser window on creation.
         window_info.ex_style |= WS_EX_NOACTIVATE;
     }
-#elif defined DUILIB_BUILD_FOR_LINUX
+#elif defined (DUILIB_BUILD_FOR_LINUX) || defined (DUILIB_BUILD_FOR_FREEBSD)
     window_info.SetAsWindowless(pWindow->NativeWnd()->GetX11WindowNumber());
 #elif defined DUILIB_BUILD_FOR_MACOS
     window_info.SetAsWindowless(pWindow->NativeWnd()->GetNSView());

--- a/duilib/CEFControl/CefWindowUtils_MacOS.mm
+++ b/duilib/CEFControl/CefWindowUtils_MacOS.mm
@@ -219,7 +219,7 @@ void SetCefWindowCursor(CefWindowHandle cefWindow, CefCursorHandle cursor)
 void RemoveCefWindowFromParent(CefWindowHandle /*cefWindow*/)
 {
     //无需实现：如果用代码实现从父View中移除，则CEF在退出时有错误，导致进程无法正常退出
-    return false;
+    return;
 }
 
 } //namespace ui

--- a/duilib/Control/DirectoryTree.cpp
+++ b/duilib/Control/DirectoryTree.cpp
@@ -921,8 +921,8 @@ bool DirectoryTree::IsChildTreeNode(TreeNode* pTreeNode, TreeNode* pChildTreeNod
 
 bool DirectoryTree::IsSamePath(const UiString& p1, const UiString& p2) const
 {
-#if !defined (DUILIB_BUILD_FOR_LINUX)
-    //Windows文件名不区分大小写
+#if !defined (DUILIB_BUILD_FOR_LINUX) && !defined (DUILIB_BUILD_FOR_FREEBSD)
+    //Windows/MacOS文件名不区分大小写，Linux/FreeBSD区分大小写
     return StringUtil::IsEqualNoCase(p1.c_str(), p2.c_str());
 #else
     return p1 == p2;
@@ -1118,7 +1118,7 @@ void DirectoryTree::RefreshPathInfo(std::vector<std::shared_ptr<RefreshNodeData>
             std::set<DString> dirSet;
             for (const FilePath& dirPath : pNodeData->m_childPaths) {
                 DString dirPathString = dirPath.ToString();
-#if !defined (DUILIB_BUILD_FOR_LINUX)
+#if !defined (DUILIB_BUILD_FOR_LINUX) && !defined (DUILIB_BUILD_FOR_FREEBSD)
                 dirPathString = StringUtil::MakeLowerString(dirPathString);
 #endif
                 if (!dirPathString.empty()) {
@@ -1132,7 +1132,7 @@ void DirectoryTree::RefreshPathInfo(std::vector<std::shared_ptr<RefreshNodeData>
 
             for (const DirectoryTree::PathInfo& pathInfo : folderList) {
                 DString filePath = pathInfo.m_filePath.ToString();
-#if !defined (DUILIB_BUILD_FOR_LINUX)
+#if !defined (DUILIB_BUILD_FOR_LINUX) && !defined (DUILIB_BUILD_FOR_FREEBSD)
                 filePath = StringUtil::MakeLowerString(filePath);
 #endif
                 if (!filePath.empty()) {

--- a/duilib/Control/DirectoryTreeImpl_Linux.cpp
+++ b/duilib/Control/DirectoryTreeImpl_Linux.cpp
@@ -509,4 +509,4 @@ void DirectoryTreeImpl::GetDiskInfoList(const std::weak_ptr<WeakFlag>& /*weakFla
 
 } //namespace ui
 
-#endif //DUILIB_BUILD_FOR_LINUX
+#endif //defined (DUILIB_BUILD_FOR_LINUX) || defined (DUILIB_BUILD_FOR_FREEBSD)

--- a/duilib/Control/RichEdit_SDL.cpp
+++ b/duilib/Control/RichEdit_SDL.cpp
@@ -598,7 +598,7 @@ void RichEdit::SetNumberFormat64(const DString& numberFormat)
     DString format = numberFormat;
 #if defined (DUILIB_BUILD_FOR_WIN)
     StringUtil::ReplaceAll(_T("lld"), _T("I64d"), format);
-#elif defined (DUILIB_BUILD_FOR_LINUX)
+#else
     StringUtil::ReplaceAll(_T("I64d"), _T("lld"), format);
 #endif
     m_numberFormat = format;

--- a/duilib/Control/RichEdit_Windows.cpp
+++ b/duilib/Control/RichEdit_Windows.cpp
@@ -66,20 +66,6 @@ public:
         IDropTarget* pDropTarget = nullptr;
         HRESULT txResult = m_pTextServices->TxGetDropTarget(&pDropTarget);
         if (SUCCEEDED(txResult) && (pDropTarget != nullptr)) {
-            //设置当前RichEdit控件的光标到鼠标所在位置，方便查看拖放目标位置
-            if (m_pRichEdit != nullptr) {
-                UiPoint clientPt = pt;
-                m_pRichEdit->ScreenToClient(clientPt);
-                if (m_pRichEdit->GetPos().ContainsPt(clientPt)) {                    
-                    int32_t pos = m_pRichEdit->CharFromPos(clientPt);
-                    if (pos >= 0) {
-                        UiPoint charPt = m_pRichEdit->PosFromChar(pos);
-                        m_pRichEdit->SetCaretPos(charPt.x, charPt.y);
-                        m_pRichEdit->ShowCaret(true);
-                    }
-                }
-            }
-
             //转接给文字服务
             DWORD dwEffect = DROPEFFECT_NONE;
             if (pdwEffect != nullptr) {
@@ -90,6 +76,22 @@ public:
                 *pdwEffect = dwEffect;
             }
             pDropTarget->Release();
+
+            if ((hr == S_OK) && (dwEffect != DROPEFFECT_NONE)) {
+                //在成功时，设置当前RichEdit控件的光标到鼠标所在位置，方便查看拖放目标位置
+                if (m_pRichEdit != nullptr) {
+                    UiPoint clientPt = pt;
+                    m_pRichEdit->ScreenToClient(clientPt);
+                    if (m_pRichEdit->GetPos().ContainsPt(clientPt)) {
+                        int32_t pos = m_pRichEdit->CharFromPos(clientPt);
+                        if (pos >= 0) {
+                            UiPoint charPt = m_pRichEdit->PosFromChar(pos);
+                            m_pRichEdit->SetCaretPos(charPt.x, charPt.y);
+                            m_pRichEdit->ShowCaret(true);
+                        }
+                    }
+                }
+            }
         }
         return hr;
     }

--- a/duilib/Utils/FilePath.cpp
+++ b/duilib/Utils/FilePath.cpp
@@ -320,8 +320,8 @@ bool FilePath::IsSubDirectory(const FilePath& parentPath) const
     if (childStr.size() <= parentStr.size()) {
         return false;
     }
-#if !defined (DUILIB_BUILD_FOR_LINUX)
-    //Windows下，不区分大小写
+#if !defined (DUILIB_BUILD_FOR_LINUX) && !defined (DUILIB_BUILD_FOR_FREEBSD)
+    //Windows/MacOS文件名不区分大小写，Linux/FreeBSD区分大小写
     parentStr = StringUtil::MakeLowerString(parentStr);
     childStr = StringUtil::MakeLowerString(childStr);
 #endif

--- a/duilib/Utils/StringConvert.cpp
+++ b/duilib/Utils/StringConvert.cpp
@@ -87,7 +87,6 @@ std::string StringConvert::WStringToUTF8(const std::wstring& wstr)
 #endif
 }
 
-#ifdef DUILIB_UTF32_SUPPORT
 std::basic_string<DUTF32Char> StringConvert::UTF8ToUTF32(const DUTF8Char* utf8, size_t length)
 {
     std::vector<DUTF32Char> data;
@@ -229,7 +228,6 @@ DStringW StringConvert::UTF32ToWString(const std::basic_string<DUTF32Char>& utf3
 {
     return UTF32ToWString(utf32.c_str(), utf32.length());
 }
-#endif // DUILIB_UTF32_SUPPORT
 
 std::string StringConvert::TToUTF8(const std::wstring& str)
 {
@@ -281,7 +279,6 @@ DString StringConvert::WStringToT(const std::wstring& wstr)
 }
 #endif
 
-#ifdef DUILIB_UTF32_SUPPORT
 std::basic_string<DUTF32Char> StringConvert::UTF8ToUTF32(const std::string& utf8)
 {
     return UTF8ToUTF32(utf8.c_str(), utf8.length());
@@ -291,7 +288,6 @@ std::string StringConvert::UTF32ToUTF8(const std::basic_string<DUTF32Char>& utf3
 {
     return UTF32ToUTF8(utf32.c_str(), utf32.length());
 }
-#endif // DUILIB_UTF32_SUPPORT
 
 #ifdef DUILIB_BUILD_FOR_WIN
 std::wstring StringConvert::MBCSToUnicode(const std::string& input, int32_t code_page)

--- a/duilib/Utils/StringConvert.h
+++ b/duilib/Utils/StringConvert.h
@@ -41,16 +41,6 @@ public:
     static DString WStringToT(const std::wstring& wstr);
 #endif
 
-#if defined(__llvm__) || defined(__clang__)
-    //LLVM 编译时，如果DUTF32Char是int32_t，会编译报错，无法匹配模板特化：struct char_traits<int>
-    #if !defined (WCHAR_T_IS_UTF16) && defined (WCHAR_T_IS_UTF32)
-        #define DUILIB_UTF32_SUPPORT 1
-    #endif
-#else
-    #define DUILIB_UTF32_SUPPORT 1
-#endif
-
-#ifdef DUILIB_UTF32_SUPPORT
     //UTF8转换为UTF32字符串
     static std::basic_string<DUTF32Char> UTF8ToUTF32(const DUTF8Char* utf8, size_t length);
     static std::basic_string<DUTF32Char> UTF8ToUTF32(const std::string& utf8);
@@ -68,7 +58,6 @@ public:
     //UTF32字符串转换为DStringW
     static DStringW UTF32ToWString(const DUTF32Char* utf32, size_t length);
     static DStringW UTF32ToWString(const std::basic_string<DUTF32Char>& utf32);
-#endif
 
 #ifdef DUILIB_BUILD_FOR_WIN
     //本地Ansi编码或者UTF8编码等转换成Unicode编码

--- a/duilib/duilib_string.h
+++ b/duilib/duilib_string.h
@@ -31,10 +31,10 @@
                 //Linux/macOS GCC: wchar_t通常是4字节(UTF-32)
                 #define WCHAR_T_IS_UTF32
             #elif (__WCHAR_MAX__ == 0x7fff || __WCHAR_MAX__ == 0xffff)
-    // On Posix, we'll detect short wchar_t, but projects aren't guaranteed to
-    // compile in this mode (in particular, Chrome doesn't). This is intended for
-    // other projects using base who manage their own dependencies and make sure
-    // short wchar works for them.
+                // On Posix, we'll detect short wchar_t, but projects aren't guaranteed to
+                // compile in this mode (in particular, Chrome doesn't). This is intended for
+                // other projects using base who manage their own dependencies and make sure
+                // short wchar works for them.
                 //某些特殊配置下可能是2字节
                 #define WCHAR_T_IS_UTF16
             #endif
@@ -43,7 +43,7 @@
     
     // 如果未检测到，默认处理
     #if !defined(WCHAR_T_IS_UTF16) && !defined(WCHAR_T_IS_UTF32)
-        // macOS默认情况下wchar_t是4字节
+        // 默认情况下（Linux/FreeBSD/MacOS平台）wchar_t是4字节
         #define WCHAR_T_IS_UTF32
     #endif
 #else
@@ -52,14 +52,11 @@
 
 typedef char DUTF8Char;
 #if defined(WCHAR_T_IS_UTF16)
-    typedef wchar_t DUTF16Char;
-    typedef int32_t DUTF32Char;
-#elif defined(__FreeBSD__) && defined(__aarch64__)
-    typedef char16_t DUTF16Char;
-    typedef wchar_t DUTF32Char;
+    typedef wchar_t  DUTF16Char;
+    typedef char32_t DUTF32Char;
 #else
-    typedef int16_t DUTF16Char;
-    typedef wchar_t DUTF32Char;
+    typedef char16_t DUTF16Char;
+    typedef wchar_t  DUTF32Char;
 #endif
 
 typedef std::basic_string<DUTF8Char> UTF8String;

--- a/duilib/third_party/libcef_linux/CMakeLists.txt
+++ b/duilib/third_party/libcef_linux/CMakeLists.txt
@@ -132,7 +132,7 @@
 #
 
 # For VS2022 and Xcode 12+ support.
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.18)
 
 # Only generate Debug and Release configuration types.
 set(CMAKE_CONFIGURATION_TYPES Debug Release)


### PR DESCRIPTION
RichEdit控件：IDropTarget::DragOver的实现优化，如果不支持拖入，则光标不跟随鼠标位置调整。
解决DUTF32Char和DUTF16Char在各个平台的兼容性问题。
修复部分FreeBSD平台的兼容性问题。
修复中科方德系统中cef模块编译失败的问题，修复中科方德系统中无法显示中文的问题（NFSDesktop 5.0）。
