### PR TITLE
发现一个BUG，菜单事件+弹出阻塞模态框会导致崩溃 #246

### DIFF
--- a/duilib/Control/Menu.cpp
+++ b/duilib/Control/Menu.cpp
@@ -1108,7 +1108,12 @@ void MenuItem::CreateMenuWnd()
 
 void MenuItem::Activate(const EventArgs* pMsg)
 {
+    std::weak_ptr<WeakFlag> weakFlag = GetWeakFlag();
     BaseClass::Activate(pMsg);
+    if (weakFlag.expired()) {
+        //在响应事件过程中，控件已经失效
+        return;
+    }
     DString itemName = GetName();
     size_t nItemIndex = GetListBoxIndex();
     Menu* pMenu = dynamic_cast<Menu*>(GetWindow());

--- a/duilib/Core/NativeWindow_SDL.cpp
+++ b/duilib/Core/NativeWindow_SDL.cpp
@@ -1815,7 +1815,7 @@ bool NativeWindow_SDL::CalculateCenterWindowPos(SDL_Window* pCenterWindow, int32
     UiRect rcArea;
     UiRect rcCenter;
     UiRect rcMonitor;
-    GetMonitorRect(m_sdlWindow != nullptr ? m_sdlWindow : pCenterWindow, rcMonitor, rcArea);
+    GetMonitorRect(pCenterWindow != nullptr ? pCenterWindow : m_sdlWindow, rcMonitor, rcArea);
     if (pCenterWindow == nullptr) {
         rcCenter = rcArea;
     }

--- a/duilib/Core/NativeWindow_Windows.cpp
+++ b/duilib/Core/NativeWindow_Windows.cpp
@@ -852,7 +852,7 @@ bool NativeWindow_Windows::CalculateCenterWindowPos(HWND hCenterWindow, int32_t&
     UiRect rcArea;
     UiRect rcCenter;
     UiRect rcMonitor;
-    GetMonitorRect(GetHWND() != nullptr ? GetHWND() : hCenterWindow, rcMonitor, rcArea);
+    GetMonitorRect(hCenterWindow != nullptr ? hCenterWindow : GetHWND(), rcMonitor, rcArea);
     if (hCenterWindow == nullptr) {
         rcCenter = rcArea;
     }
@@ -863,22 +863,27 @@ bool NativeWindow_Windows::CalculateCenterWindowPos(HWND hCenterWindow, int32_t&
         GetWindowRect(hCenterWindow, rcCenter);
     }
 
+    //屏幕编译留出空隙，避免出现贴边操作
+    UINT dpi = 96;
+    GetDpiForWindowWrapper(hCenterWindow != nullptr ? hCenterWindow : GetHWND(), dpi);
+    const int32_t snapThreshold = MulDiv(3, dpi, 96);
+
     // Find dialog's upper left based on rcCenter
     int32_t xLeft = rcCenter.CenterX() - nWindowWidth / 2;
     int32_t yTop = rcCenter.CenterY() - nWindowHeight / 2;
 
     // The dialog is outside the screen, move it inside
     if (xLeft < rcArea.left) {
-        xLeft = rcArea.left;
+        xLeft = rcArea.left + snapThreshold;
     }
     else if (xLeft + nWindowWidth > rcArea.right) {
-        xLeft = rcArea.right - nWindowWidth;
+        xLeft = rcArea.right - nWindowWidth - snapThreshold;
     }
     if (yTop < rcArea.top) {
-        yTop = rcArea.top;
+        yTop = rcArea.top + snapThreshold;
     }
     else if (yTop + nWindowHeight > rcArea.bottom) {
-        yTop = rcArea.bottom - nWindowHeight;
+        yTop = rcArea.bottom - nWindowHeight - snapThreshold;
     }
     xPos = xLeft;
     yPos = yTop;

--- a/duilib/Core/WindowBase.cpp
+++ b/duilib/Core/WindowBase.cpp
@@ -716,7 +716,7 @@ void WindowBase::SetWindowMinimumSize(const UiSize& szMaxWindow, bool bNeedDpiSc
 
 const UiSize& WindowBase::GetWindowMinimumSize() const
 {
-    return NativeWnd()->GetWindowMaximumSize();
+    return NativeWnd()->GetWindowMinimumSize();
 }
 
 int32_t WindowBase::SetWindowHotKey(uint8_t wVirtualKeyCode, uint8_t wModifiers)


### PR DESCRIPTION
发现一个BUG，菜单事件+弹出阻塞模态框会导致崩溃 #246:
(1) 修复XML ：Window size="320,400" min_size="320,400" max_size="600,600" 窗口会以 600x600来显示的问题
(2) 修复在多显示器的情况下，CalculateCenterWindowPos 计算不正确导致的弹窗窗口出现在第二个显示器