### PR TITLE
父组件在被显示的时候，会导致子组件visible也为ture（#254）

### DIFF
--- a/duilib/Box/ScrollBox.cpp
+++ b/duilib/Box/ScrollBox.cpp
@@ -629,15 +629,16 @@ void ScrollBox::PaintChild(IRender* pRender, const UiRect& rcPaint)
     }
 }
 
-void ScrollBox::SetMouseEnabled(bool bEnabled)
+void ScrollBox::OnSetMouseEnabled(bool bChanged)
 {
+    BaseClass::OnSetMouseEnabled(bChanged);
+    bool bEnabled = IsEnabled();
     if (m_pVScrollBar != nullptr) {
         m_pVScrollBar->SetMouseEnabled(bEnabled);
     }
     if (m_pHScrollBar != nullptr) {
         m_pHScrollBar->SetMouseEnabled(bEnabled);
     }
-    Box::SetMouseEnabled(bEnabled);
 }
 
 void ScrollBox::SetParent(Box* pParent)

--- a/duilib/Box/ScrollBox.h
+++ b/duilib/Box/ScrollBox.h
@@ -31,7 +31,6 @@ public:
     virtual bool MouseEnter(const EventArgs& msg) override;
     virtual bool MouseLeave(const EventArgs& msg) override;
     virtual void PaintChild(IRender* pRender, const UiRect& rcPaint) override;
-    virtual void SetMouseEnabled(bool bEnable = true) override;
     virtual void SetParent(Box* pParent) override;
     virtual void SetWindow(Window* pWindow) override;
     virtual Control* FindControl(FINDCONTROLPROC Proc, void* pProcData,
@@ -269,6 +268,11 @@ protected:
      * @return 返回所需尺寸大小, 包含ScrollBox自身的内边距，不包含外边距
      */
     virtual UiSize64 CalcRequiredSize(const UiRect& rc);
+
+    /** 设置鼠标可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetMouseEnabled(bool bChanged) override;
 
 private:
     /** 设置位置大小

--- a/duilib/Box/TabBox.cpp
+++ b/duilib/Box/TabBox.cpp
@@ -37,16 +37,16 @@ void TabBox::SetAttribute(const DString& strName, const DString& strValue)
     }
 }
 
-void TabBox::SetVisible(bool bVisible)
+void TabBox::OnSetVisible(bool bChanged)
 {
-    if (!IsInited() || !bVisible) {
-        //未初始化或者隐藏时，调用基类的实现
-        BaseClass::SetVisible(bVisible);
+    BaseClass::OnSetVisible(bChanged);
+
+    if (!IsInited() || !IsVisible()) {
+        //未初始化或者隐藏时，不处理
         return;
     }
 
-    //显示时，只能显示一个页面，其他页面需要隐藏
-    BaseClass::SetVisible(bVisible);
+    //显示时，只能显示一个页面，其他页面需要隐藏    
     size_t nCurSel = GetCurSel();
     bool bSelected = false;
     if (Box::IsValidItemIndex(nCurSel)) {

--- a/duilib/Box/TabBox.h
+++ b/duilib/Box/TabBox.h
@@ -18,7 +18,6 @@ public:
     /// 重写父类方法，提供个性化功能，请参考父类声明
     virtual DString GetType() const override;
     virtual void SetAttribute(const DString& strName, const DString& strValue) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual bool AddItem(Control* pControl) override;
     virtual bool AddItemAt(Control* pControl, size_t iIndex) override;
     virtual bool RemoveItem(Control* pControl) override;
@@ -78,6 +77,12 @@ protected:
     *@param [in] it TAB 项索引
     */
     void OnAnimationComplete(size_t index);
+
+protected:
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
 
 private:
     /** 根据控件索引选择一个子项

--- a/duilib/Box/VirtualListBox.h
+++ b/duilib/Box/VirtualListBox.h
@@ -64,10 +64,18 @@ public:
 
 public:
     /** 注册事件通知回调
-    * @param [in] dcNotify 数据内容变化通知接口
-    * @param [in] ccNotify 数据项个数变化通知接口
+    * @param [in] pVirtualListBox 关联的VirtualListBox对象
+    * @param [in] dcNotify 数据内容变化通知回调函数
+    * @param [in] ccNotify 数据项个数变化通知回调函数
     */
-    void RegNotifys(const DataChangedNotify& dcNotify, const CountChangedNotify& ccNotify);
+    void RegNotifys(VirtualListBox* pVirtualListBox,
+                    const DataChangedNotify& dcNotify,
+                    const CountChangedNotify& ccNotify);
+
+    /** 注销事件通知回调
+    * @param [in] pVirtualListBox 关联的VirtualListBox对象
+    */
+    void UnRegNotifys(VirtualListBox* pVirtualListBox);
 
 protected:
 
@@ -82,12 +90,15 @@ protected:
     void EmitCountChanged();
 
 private:
+    /** 回调函数关联的VirtualListBox对象
+    */
+    VirtualListBox* m_pVirtualListBox;
 
-    /** 数据内容发生变化的响应函数
+    /** 数据内容发生变化的回调函数
     */
     DataChangedNotify m_pfnDataChangedNotify;
 
-    /** 数据个数发生变化的响应函数
+    /** 数据个数发生变化的回调函数
     */
     CountChangedNotify m_pfnCountChangedNotify;
 };

--- a/duilib/CEFControl/CefControlNative.cpp
+++ b/duilib/CEFControl/CefControlNative.cpp
@@ -131,10 +131,10 @@ bool CefControlNative::OnKillFocus(const EventArgs& msg)
     return BaseClass::OnKillFocus(msg);
 }
 
-void CefControlNative::SetVisible(bool bVisible)
+void CefControlNative::OnSetVisible(bool bChanged)
 {
     GlobalManager::Instance().AssertUIThread();
-    BaseClass::SetVisible(bVisible);
+    BaseClass::OnSetVisible(bChanged);
 
     //更新页面子窗口的可见性
     SetCefWindowVisible(GetCefWindowHandle(), this);

--- a/duilib/CEFControl/CefControlNative.h
+++ b/duilib/CEFControl/CefControlNative.h
@@ -23,7 +23,6 @@ public:
     virtual void SetPos(ui::UiRect rc) override;
     virtual bool OnSetFocus(const EventArgs& msg) override;
     virtual bool OnKillFocus(const EventArgs& msg) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual void SetWindow(ui::Window* pWindow) override;
 
 protected:
@@ -50,6 +49,11 @@ protected:
     /** 页面获得了焦点
     */
     virtual void OnGotFocus() override;
+
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
 
 private:
     /** 关闭所有的Browser对象

--- a/duilib/CEFControl/CefControlOffScreen.cpp
+++ b/duilib/CEFControl/CefControlOffScreen.cpp
@@ -171,12 +171,12 @@ void CefControlOffScreen::SetPos(UiRect rc)
     }
 }
 
-void CefControlOffScreen::SetVisible(bool bVisible)
+void CefControlOffScreen::OnSetVisible(bool bChanged)
 {
     GlobalManager::Instance().AssertUIThread();
-    BaseClass::SetVisible(bVisible);
+    BaseClass::OnSetVisible(bChanged);
     if (m_pBrowserHandler.get() && m_pBrowserHandler->GetBrowserHost().get()) {
-        m_pBrowserHandler->GetBrowserHost()->WasHidden(!bVisible);
+        m_pBrowserHandler->GetBrowserHost()->WasHidden(!IsVisible());
     }
 }
 

--- a/duilib/CEFControl/CefControlOffScreen.h
+++ b/duilib/CEFControl/CefControlOffScreen.h
@@ -32,7 +32,6 @@ public:
     /// 重写父类接口，提供个性化功能
     virtual void Init() override;
     virtual void SetPos(UiRect rc) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual void Paint(IRender* pRender, const UiRect& rcPaint) override;
     virtual void SetWindow(Window* pWindow) override;
 
@@ -49,6 +48,11 @@ public:
     virtual std::shared_ptr<IBitmap> MakeImageSnapshot() override;
 
 protected:
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
+
     /** 重新创建Browser控件
     */
     virtual void ReCreateBrowser() override;

--- a/duilib/Control/AddressBar.cpp
+++ b/duilib/Control/AddressBar.cpp
@@ -168,10 +168,10 @@ DString AddressBar::GetPathSeparatorClass() const
     return m_pathSeparatorClass.c_str();
 }
 
-void AddressBar::SetVisible(bool bVisible)
+void AddressBar::OnSetVisible(bool bChanged)
 {
-    BaseClass::SetVisible(bVisible);
-    if (bVisible) {
+    BaseClass::OnSetVisible(bChanged);
+    if (IsVisible()) {
         ShowAddressEdit(false);
         UpdateAddressBarControlsStatus();
     }

--- a/duilib/Control/AddressBar.h
+++ b/duilib/Control/AddressBar.h
@@ -19,7 +19,6 @@ public:
     */
     virtual DString GetType() const override;
     virtual void SetAttribute(const DString& strName, const DString& strValue) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual void SetPos(UiRect rc) override;
 
     /** 设置路径
@@ -149,6 +148,11 @@ protected:
     /** 初始化
     */
     virtual void OnInit() override;
+
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
 
 private:
     /** 添加一个路径

--- a/duilib/Control/DateTime.cpp
+++ b/duilib/Control/DateTime.cpp
@@ -342,17 +342,17 @@ void DateTime::HandleEvent(const EventArgs& msg)
         SetCursor(CursorType::kCursorIBeam);
         return;
     }
-    if (msg.eventType == kEventWindowSize) {
+    else if (msg.eventType == kEventWindowSize) {
         if (m_pDateWindow != nullptr) {
             return;
         }
     }
-    if (msg.eventType == kEventScrollChange) {
+    else if (msg.eventType == kEventScrollChange) {
         if (m_pDateWindow != nullptr) {
             return;
         }
     }
-    if (msg.eventType == kEventSetFocus) {
+    else if (msg.eventType == kEventSetFocus) {
         if (m_pDateWindow != nullptr) {
             return;
         }
@@ -371,12 +371,12 @@ void DateTime::HandleEvent(const EventArgs& msg)
             }
         }
     }
-    if (msg.eventType == kEventKillFocus) {
+    else if (msg.eventType == kEventKillFocus) {
         Invalidate();
     }
-    if ((msg.eventType == kEventMouseButtonDown) ||
-        (msg.eventType == kEventMouseDoubleClick) ||
-        (msg.eventType == kEventMouseRButtonDown)) {
+    else if ((msg.eventType == kEventMouseButtonDown) ||
+             (msg.eventType == kEventMouseDoubleClick) ||
+             (msg.eventType == kEventMouseRButtonDown)) {
         if (GetWindow() != nullptr) {
             GetWindow()->ReleaseCapture();
         }
@@ -393,22 +393,24 @@ void DateTime::HandleEvent(const EventArgs& msg)
             }
         }
     }
-    if (msg.eventType == kEventMouseMove) {
+    else if (msg.eventType == kEventMouseMove) {
         return;
     }
-    if (msg.eventType == kEventMouseButtonUp) {
+    else if (msg.eventType == kEventMouseButtonUp) {
         return;
     }
-    if (msg.eventType == kEventContextMenu) {
+    else if (msg.eventType == kEventContextMenu) {
         return;
     }
-    if (msg.eventType == kEventMouseEnter) {
+    else if (msg.eventType == kEventMouseEnter) {
         return;
     }
-    if (msg.eventType == kEventMouseLeave) {
+    else if (msg.eventType == kEventMouseLeave) {
         return;
     }
-    BaseClass::HandleEvent(msg);
+    else {
+        BaseClass::HandleEvent(msg);
+    }
 }
 
 void DateTime::OnInit()

--- a/duilib/Control/ListCtrl.cpp
+++ b/duilib/Control/ListCtrl.cpp
@@ -2536,6 +2536,7 @@ void ListCtrl::UpdateRichEditSize(ListCtrlLabel* pSubItem)
         }
 
         UiMargin rcMargin(rcItem.left - rect.left, rcItem.top - rect.top, 0, 0);
+        rcMargin.Validate();
         m_pRichEdit->SetMargin(rcMargin, false);
 
         m_pRichEdit->SetMinWidth(rcItem.Width(), false);

--- a/duilib/Control/ListCtrlHeaderItem.h
+++ b/duilib/Control/ListCtrlHeaderItem.h
@@ -229,7 +229,7 @@ protected:
 protected:
     //禁止外部调用调整可见性的函数，避免数据不同步
     virtual void SetFadeVisible(bool bVisible) override;
-    virtual void SetVisible(bool bVisible) override;
+    void SetVisible(bool bVisible);
 
 private:
     /** 关联的Header接口

--- a/duilib/Control/ListCtrlReportView.cpp
+++ b/duilib/Control/ListCtrlReportView.cpp
@@ -760,7 +760,7 @@ Control* ListCtrlReportView::FindControl(FINDCONTROLPROC Proc, void* pProcData,
                                          uint32_t uFlags, const UiPoint& ptMouse,
                                          const UiPoint& scrollPos)
 {
-    //重写：ScrollBox::FindControl 函数，让Header优先被查找到，只处理含有UIFIND_TOP_FIRST标志的情况
+    //重写：ScrollBox::FindControl 函数，让Header/置顶的Item优先被查找到，只处理含有UIFIND_TOP_FIRST标志的情况
     if ((uFlags & UIFIND_TOP_FIRST) == 0) {
         return BaseClass::FindControl(Proc, pProcData, uFlags, ptMouse, scrollPos);
     }
@@ -820,7 +820,7 @@ Control* ListCtrlReportView::FindControl(FINDCONTROLPROC Proc, void* pProcData,
 
     UiSize boxScrollOffset = GetScrollOffset();
     UiPoint boxScrollPos(boxScrollOffset.cx, boxScrollOffset.cy);
-    return FindControlInItems(m_items, Proc, pProcData, uFlags, boxPt, boxScrollPos);
+    return FindControlInItems(newItems, Proc, pProcData, uFlags, boxPt, boxScrollPos);
 }
 
 Control* ListCtrlReportView::CreateDataItem()

--- a/duilib/Control/Menu.cpp
+++ b/duilib/Control/Menu.cpp
@@ -1108,7 +1108,12 @@ void MenuItem::CreateMenuWnd()
 
 void MenuItem::Activate(const EventArgs* pMsg)
 {
+    std::weak_ptr<WeakFlag> weakFlag = GetWeakFlag();
     BaseClass::Activate(pMsg);
+    if (weakFlag.expired()) {
+        //在响应事件过程中，控件已经失效
+        return;
+    }
     DString itemName = GetName();
     size_t nItemIndex = GetListBoxIndex();
     Menu* pMenu = dynamic_cast<Menu*>(GetWindow());

--- a/duilib/Control/RichEditHost_Windows.cpp
+++ b/duilib/Control/RichEditHost_Windows.cpp
@@ -1037,6 +1037,12 @@ void RichEditHost::SetHideSelection(bool fHideSelection)
         m_dwStyle &= ~UI_ES_NOHIDESEL;
     }
     OnTxPropertyBitsChange(TXTBIT_HIDESELECTION, fHideSelection ? TXTBIT_HIDESELECTION : 0);
+    if (fHideSelection) {
+        ASSERT(IsHideSelection());
+    }
+    else {
+        ASSERT(!IsHideSelection());
+    }
 }
 
 bool RichEditHost::IsHideSelection() const

--- a/duilib/Control/RichEditHost_Windows.cpp
+++ b/duilib/Control/RichEditHost_Windows.cpp
@@ -2,6 +2,7 @@
 #include "RichEdit_Windows.h"
 #include "duilib/Core/GlobalManager.h"
 #include "duilib/Core/Window.h"
+#include "duilib/Utils/StringConvert.h"
 
 #if defined (DUILIB_BUILD_FOR_WIN) && !defined (DUILIB_BUILD_FOR_SDL)
 
@@ -808,6 +809,22 @@ void RichEditHost::SetFlashPasswordChar(bool bFlash)
 bool RichEditHost::IsFlashPasswordChar() const
 {
     return m_bFlashPasswordChar;
+}
+
+DString RichEditHost::GetPasswordText() const
+{
+    DString pwdText;
+    if (IsPassword() && (m_pTextServices != nullptr)) {        
+        ITextServices* pTextServices = m_pTextServices;
+        BSTR bstrText = nullptr;
+        HRESULT hr = pTextServices->TxGetText(&bstrText);
+        if ((hr == S_OK) && (bstrText != nullptr)) {
+            std::wstring pwdTextW(bstrText, SysStringLen(bstrText));
+            ::SysFreeString(bstrText);
+            pwdText = StringConvert::WStringToT(pwdTextW);
+        }        
+    }
+    return pwdText;
 }
 
 bool RichEditHost::IsNumberOnly() const

--- a/duilib/Control/RichEditHost_Windows.h
+++ b/duilib/Control/RichEditHost_Windows.h
@@ -59,6 +59,7 @@ public:
     bool IsShowPassword() const;//是否显示密码
     void SetFlashPasswordChar(bool bFlash);
     bool IsFlashPasswordChar() const;
+    DString GetPasswordText() const;
 
     //是否只允许输入数字字符
     bool IsNumberOnly() const;

--- a/duilib/Control/RichEdit_SDL.cpp
+++ b/duilib/Control/RichEdit_SDL.cpp
@@ -1644,10 +1644,9 @@ void RichEdit::EndRight()
     BaseClass::EndRight();
 }
 
-void RichEdit::SetEnabled(bool bEnable)
+void RichEdit::OnSetEnabled(bool bChanged)
 {
-    bool bChanged = IsEnabled() != bEnable;
-    BaseClass::SetEnabled(bEnable);
+    BaseClass::OnSetEnabled(bChanged);
     if (IsEnabled()) {
         SetState(kControlStateNormal);
     }

--- a/duilib/Control/RichEdit_SDL.h
+++ b/duilib/Control/RichEdit_SDL.h
@@ -44,8 +44,7 @@ public:
     //基类的虚函数重写
     virtual DString GetType() const override;
     virtual void SetAttribute(const DString& pstrName, const DString& pstrValue) override;
-    virtual void HandleEvent(const EventArgs& msg) override;
-    virtual void SetEnabled(bool bEnable = true) override;    
+    virtual void HandleEvent(const EventArgs& msg) override; 
     virtual void SetWindow(Window* pWindow) override;
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
     virtual void PaintStateImages(IRender* pRender) override;
@@ -868,6 +867,11 @@ protected:
     /** 获取文本限制长度
     */
     virtual int32_t GetTextLimitLength() const override;
+
+    /** 设置可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetEnabled(bool bChanged) override;
 
 private:
     void OnLButtonDown(const UiPoint& ptMouse, Control* pSender, bool bShiftDown);

--- a/duilib/Control/RichEdit_Windows.cpp
+++ b/duilib/Control/RichEdit_Windows.cpp
@@ -1103,6 +1103,11 @@ int32_t RichEdit::GetTextLength() const
 
 DString RichEdit::GetText() const
 {
+    if ((m_pRichHost != nullptr) && m_pRichHost->IsPassword()) {
+        //密码模式: 使用底层接口直接获取文本
+        return m_pRichHost->GetPasswordText();
+    }
+
     UINT uCodePage = 1200;
     int32_t nTextLen = m_richCtrl.GetTextLengthEx(GTL_DEFAULT, uCodePage);
     if (nTextLen < 1) {

--- a/duilib/Control/RichEdit_Windows.cpp
+++ b/duilib/Control/RichEdit_Windows.cpp
@@ -1692,9 +1692,9 @@ void RichEdit::OnInit()
     }
 }
 
-void RichEdit::SetEnabled(bool bEnable /*= true*/)
+void RichEdit::OnSetEnabled(bool bChanged)
 {
-    BaseClass::SetEnabled(bEnable);
+    BaseClass::OnSetEnabled(bChanged);
     if (IsEnabled()) {
         SetState(kControlStateNormal);
         UiColor dwTextColor = GetUiColor(GetTextColor());

--- a/duilib/Control/RichEdit_Windows.h
+++ b/duilib/Control/RichEdit_Windows.h
@@ -1112,6 +1112,8 @@ private:
 
     bool m_bNoSelOnKillFocus;   //失去焦点的时候，取消文本选择（针对 m_bEnabled && IsReadOnly()）
     bool m_bSelAllOnFocus;      //获取焦点的时候，全选文本（针对 m_bEnabled && !IsReadOnly()）
+    bool m_bHideSelection;      //是否隐藏选择状态
+    bool m_bContextMenuShown;   //是否正在显示右键菜单
 
     bool m_bIsComposition;      //输入法合成窗口是否可见
 

--- a/duilib/Control/RichEdit_Windows.h
+++ b/duilib/Control/RichEdit_Windows.h
@@ -49,7 +49,6 @@ public:
     //基类的虚函数重写
     virtual DString GetType() const override;
     virtual void SetAttribute(const DString& pstrName, const DString& pstrValue) override;
-    virtual void SetEnabled(bool bEnable = true) override;
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
     virtual void SetPos(UiRect rc) override;
     virtual void SetScrollPos(UiSize64 szPos) override;
@@ -952,6 +951,11 @@ protected:
      * @param[in] items 控件列表
      */
     virtual void ArrangeChild(const std::vector<Control*>& items) const;
+
+    /** 设置可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetEnabled(bool bChanged) override;
 
 private:
     /** 显示RichEdit上的菜单

--- a/duilib/Control/TabCtrl.cpp
+++ b/duilib/Control/TabCtrl.cpp
@@ -318,9 +318,9 @@ void TabCtrlItem::HandleEvent(const EventArgs& msg)
     }
 }
 
-void TabCtrlItem::SetVisible(bool bVisible)
+void TabCtrlItem::OnSetVisible(bool bChanged)
 {
-    BaseClass::SetVisible(bVisible);
+    BaseClass::OnSetVisible(bChanged);
     CheckIconVisible();
     if (IsVisible() && (m_pCloseBtn != nullptr)) {
         m_pCloseBtn->SetVisible(!IsAutoHideCloseButton() || IsSelected());

--- a/duilib/Control/TabCtrl.h
+++ b/duilib/Control/TabCtrl.h
@@ -122,7 +122,6 @@ public:
     */
     virtual DString GetType() const override;
     virtual void SetAttribute(const DString& strName, const DString& strValue) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual DString GetToolTipText() const override;
 
 public:
@@ -294,6 +293,12 @@ protected:
     */
     virtual void PaintTabItemHot(IRender* pRender);
 
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
+
+protected:
     /** 填充路径, 形成圆角矩形
     */
     void AddTabItemPath(IPath* path, const UiRect& rect, UiSize roundSize) const;

--- a/duilib/Control/TreeView.cpp
+++ b/duilib/Control/TreeView.cpp
@@ -344,9 +344,9 @@ bool TreeNode::OnNodeCheckStatusChanged(const EventArgs& msg)
     return true;
 }
 
-bool TreeNode::IsVisible() const
+bool TreeNode::IsVisibleInternal() const
 {
-    if (!ListBoxItem::IsVisible()) {
+    if (!BaseClass::IsVisibleInternal()) {
         return false;
     }
     if (m_pParentTreeNode != nullptr) {

--- a/duilib/Control/TreeView.h
+++ b/duilib/Control/TreeView.h
@@ -30,7 +30,6 @@ public:
     /// 重写父类方法，提供个性化功能，请参考父类声明
     virtual DString GetType() const override;
     virtual void SetAttribute(const DString& strName, const DString& strValue) override;
-    virtual bool IsVisible() const override;
     virtual bool SupportCheckedMode() const override;
 
     /** DPI发生变化，更新控件大小和布局
@@ -38,6 +37,11 @@ public:
     * @param [in] nNewDpiScale 新的DPI缩放百分比，与Dpi().GetScale()的值一致
     */
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
+
+protected:
+    /** 可见状态（供内部子类重写可见状态使用, 如果返回true代表可见，返回false表示不可见）
+    */
+    virtual bool IsVisibleInternal() const override;
 
 private:
     virtual void PaintStateImages(IRender* pRender) override;

--- a/duilib/Core/Box.cpp
+++ b/duilib/Core/Box.cpp
@@ -165,39 +165,29 @@ void Box::PaintFocusRect(IRender* /*pRender*/)
 {
 }
 
-void Box::SetEnabled(bool bEnabled)
+void Box::OnSetEnabled(bool bChanged)
 {
-    if (BaseClass::IsEnabled() == bEnabled) {
-        return;
-    }
-
-    BaseClass::SetEnabled(bEnabled);
-
-    //子控件的Enable状态，与父控件是同步的(如果支持不同步，相关业务逻辑需要做调整)
+    BaseClass::OnSetEnabled(bChanged);
+    bool bAncestorEnabled = IsEnabled();
     for (auto pControl : m_items) {
         ASSERT(pControl != nullptr);
         if (pControl != nullptr) {
-            pControl->SetEnabled(bEnabled);
+            pControl->SetAncestorEnabled(bAncestorEnabled);
         }
     }
-
-    Invalidate();
+    if (bChanged) {
+        Invalidate();
+    }
 }
 
-void Box::SetVisible(bool bVisible)
+void Box::OnSetVisible(bool bChanged)
 {
-    if (BaseClass::IsVisible() == bVisible) {
-        return;
-    }
-    bool v = BaseClass::IsVisible();
-    BaseClass::SetVisible(bVisible);
-    if (BaseClass::IsVisible() != v) {
-        //子控件的Visible控件是同步的(如果支持不同步，相关业务逻辑需要做调整，除了判断控件自身是否可见，还要判断父控件是否可见)
-        for (auto pControl : m_items){
-            ASSERT(pControl != nullptr);
-            if (pControl != nullptr) {
-                pControl->SetVisible(bVisible);
-            }
+    BaseClass::OnSetVisible(bChanged);
+    bool bAncestorVisible = IsVisible();
+    for (auto pControl : m_items) {
+        ASSERT(pControl != nullptr);
+        if (pControl != nullptr) {
+            pControl->SetAncestorVisible(bAncestorVisible);
         }
     }
 }
@@ -468,13 +458,9 @@ bool Box::DoAddItemAt(Control* pControl, size_t iIndex)
     }
     pControl->SetParent(this);
 
-    //同步Enable属性和Visible属性(只同步基类的值)
-    if (!BaseClass::IsEnabled()) {
-        pControl->SetEnabled(BaseClass::IsEnabled());
-    }
-    if (!Control::IsVisible()) {
-        pControl->SetVisible(BaseClass::IsVisible());
-    }
+    //同步Enable属性和Visible属性
+    pControl->SetAncestorEnabled(IsEnabled());
+    pControl->SetAncestorVisible(IsVisible());
 
     //在添加到父容器以后，调用初始化函数
     pControl->Init();

--- a/duilib/Core/Box.h
+++ b/duilib/Core/Box.h
@@ -35,8 +35,6 @@ public:
     virtual void SetAttribute(const DString& strName, const DString& strValue) override;
     virtual void PaintChild(IRender* pRender, const UiRect& rcPaint) override;
     virtual void PaintFocusRect(IRender* pRender) override;
-    virtual void SetEnabled(bool bEnabled) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual Control* FindControl(FINDCONTROLPROC Proc, void* pProcData, uint32_t uFlags,
                                  const UiPoint& ptMouse = UiPoint(),
                                  const UiPoint& scrollPos = UiPoint()) override;
@@ -211,6 +209,17 @@ protected:
                                 uint32_t uFlags, 
                                 const UiPoint& ptMouse, 
                                 const UiPoint& scrollPos);
+
+protected:
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
+
+    /** 设置可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetEnabled(bool bChanged) override;
 
 private:
     /**@brief 向指定位置添加一个控件

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -1496,19 +1496,14 @@ void Control::SetFadeVisible(bool bVisible)
     }
 }
 
-void Control::SetVisible(bool bVisible)
+void Control::OnSetVisible(bool bChanged)
 {
-    if (IsVisible() == bVisible) {
-        return;
-    }
-    bool v = IsVisible();
-    BaseClass::SetVisible(bVisible);
-
+    BaseClass::OnSetVisible(bChanged);
     if (!IsVisible()) {
         EnsureNoFocus();
     }
 
-    if (IsVisible() != v) {
+    if (bChanged) {
         ArrangeAncestor();
     }
 
@@ -1519,15 +1514,9 @@ void Control::SetVisible(bool bVisible)
     SendEvent(kEventVisibleChange);
 }
 
-bool Control::IsEnabled() const
+void Control::OnSetEnabled(bool bChanged)
 {
-    return BaseClass::IsEnabled();
-}
-
-void Control::SetEnabled(bool bEnabled)
-{
-    bool bChanged = IsEnabled() != bEnabled;
-    BaseClass::SetEnabled(bEnabled);
+    BaseClass::OnSetEnabled(bChanged);
     if (IsEnabled()) {
         PrivateSetState(kControlStateNormal);
         m_nHotAlpha = 0;

--- a/duilib/Core/Control.h
+++ b/duilib/Core/Control.h
@@ -421,25 +421,10 @@ public:
     /// 一些重要的属性
     /** 以淡入淡出等动画形式设置控件是否可见, 调用的结果与SetVisible相同，只是过程包含了动画效果。
         调用SetFadeVisible以后，不需要再调用SetVisible函数修改可见属性。
-        该函数内部会调用SetVisible这个虚函数。
+        该函数内部会调用SetVisible这个函数。
      * @param[in] bVisible 为 true 时控件可见，为 false 时控件被隐藏
      */
     virtual void SetFadeVisible(bool bVisible);
-
-    /** 设置控件是否可见
-     * @param [in] @param[in] bVisible 为 true 时控件可见，为 false 时控件被隐藏
-     */
-    virtual void SetVisible(bool bVisible) override;
-
-    /** 检查控件是否可用
-     * @return 控件可用状态，返回 true 控件可用，否则为 false
-     */
-    virtual bool IsEnabled() const override;
-
-    /** 设置控件可用状态
-     * @param [in] bEnable 为 true 时控件可用，为 false 时控件为禁用状态则不可用
-     */
-    virtual void SetEnabled(bool bEnable) override;
 
     /** 检查控件是否具有焦点
      * @return 返回控件是否具有检点，为 true 时是当前具有焦点，为 false 时控件没有焦点
@@ -1278,6 +1263,17 @@ public:
     * @return 成功返回字体接口，外部调用不需要释放资源；如果失败则返回nullptr
     */
     IFont* GetIFontById(const DString& strFontId) const;
+
+protected:
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
+
+    /** 设置可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetEnabled(bool bChanged) override;
 
 private:
 

--- a/duilib/Core/ControlPtrT.h
+++ b/duilib/Core/ControlPtrT.h
@@ -185,6 +185,8 @@ typedef ControlPtrT<Control> ControlPtr;
 class Box;
 typedef ControlPtrT<Box> BoxPtr;
 
+class Window;
+typedef ControlPtrT<Window> WindowPtr;
 
 } // namespace ui
 

--- a/duilib/Core/GlobalManager.h
+++ b/duilib/Core/GlobalManager.h
@@ -13,6 +13,7 @@
 #include "duilib/Core/ResourceParam.h"
 #include "duilib/Core/CursorManager.h"
 #include "duilib/Core/IconManager.h"
+#include "duilib/Core/WindowManager.h"
 
 #include <string>
 #include <vector>
@@ -137,22 +138,6 @@ public:
                          const DString& languageNameID = _T("LANGUAGE_DISPLAY_NAME")) const;
 
 public:
-    /** 添加一个窗口接口（主要用于换肤、切换语言之后的重绘、资源同步等操作）
-    * @param [in] pWindow 窗口的接口
-    */
-    void AddWindow(Window* pWindow);
-
-    /** 移除一个窗口
-    * @param [in] pWindow 窗口的接口
-    */
-    void RemoveWindow(Window* pWindow);
-
-    /** 判断当前是否含有窗口
-    * @param [in] pWindow 窗口的接口
-    */
-    bool HasWindow(Window* pWindow) const;
-    bool HasWindowBase(WindowBase* pWindowBase) const;
-
     /** 添加一个全局 Class 属性
      * @param[in] strClassName 全局 Class 名称
      * @param[in] strControlAttrList 属性列表，需要做 XML 转义
@@ -214,6 +199,10 @@ public:
     /** 光标管理器
     */
     CursorManager& Cursor();
+
+    /** 窗口管理器
+    */
+    WindowManager& Windows();
 
 public:
     /** 根据资源加载方式，返回对应的资源路径
@@ -326,20 +315,6 @@ private:
     */
     std::thread::id m_dwUiThreadId;
 
-    /** 所有的窗口列表
-    */
-    struct WindowWeakFlag
-    {
-        /** 窗口的接口
-        */
-        Window* m_pWindow = nullptr;
-        
-        /** 窗口接口的有效期标志
-        */
-        std::weak_ptr<WeakFlag> m_weakFlag;
-    };
-    std::vector<WindowWeakFlag> m_windowList;
-
     /** 颜色管理器
     */
     ColorManager m_colorManager;
@@ -379,6 +354,10 @@ private:
     /** 光标管理器
     */
     CursorManager m_cursorManager;
+
+    /** 窗口管理器
+    */
+    WindowManager m_windowManager;
 
     /** 退出时要执行的函数
     */

--- a/duilib/Core/NativeWindow_SDL.cpp
+++ b/duilib/Core/NativeWindow_SDL.cpp
@@ -1815,7 +1815,7 @@ bool NativeWindow_SDL::CalculateCenterWindowPos(SDL_Window* pCenterWindow, int32
     UiRect rcArea;
     UiRect rcCenter;
     UiRect rcMonitor;
-    GetMonitorRect(m_sdlWindow != nullptr ? m_sdlWindow : pCenterWindow, rcMonitor, rcArea);
+    GetMonitorRect(pCenterWindow != nullptr ? pCenterWindow : m_sdlWindow, rcMonitor, rcArea);
     if (pCenterWindow == nullptr) {
         rcCenter = rcArea;
     }

--- a/duilib/Core/NativeWindow_SDL.cpp
+++ b/duilib/Core/NativeWindow_SDL.cpp
@@ -2165,6 +2165,18 @@ void NativeWindow_SDL::SetText(const DString& strText)
     ASSERT_UNUSED_VARIABLE(nRet);
 }
 
+DString NativeWindow_SDL::GetText() const
+{
+    DString windowText;
+    if (m_sdlWindow != nullptr) {
+        const char* szText = SDL_GetWindowTitle(m_sdlWindow);
+        if (szText != nullptr) {
+            windowText = StringConvert::UTF8ToT(szText);
+        }
+    }
+    return windowText;
+}
+
 void NativeWindow_SDL::SetWindowMaximumSize(const UiSize& szMaxWindow)
 {
     m_szMaxWindow = szMaxWindow;

--- a/duilib/Core/NativeWindow_SDL.h
+++ b/duilib/Core/NativeWindow_SDL.h
@@ -326,6 +326,10 @@ public:
     */
     void SetText(const DString& strText);
 
+    /** 获取窗口标题栏文本
+    */
+    DString GetText() const;
+
     /** 设置窗口大小的最小值（宽度和高度，内部不按DPI调整大小，DPI自适应需要调用方来做）
     * @param [in] szMaxWindow 窗口的最大宽度和最小高度，如果值为0，表示不做限制
     */

--- a/duilib/Core/NativeWindow_Windows.cpp
+++ b/duilib/Core/NativeWindow_Windows.cpp
@@ -852,7 +852,7 @@ bool NativeWindow_Windows::CalculateCenterWindowPos(HWND hCenterWindow, int32_t&
     UiRect rcArea;
     UiRect rcCenter;
     UiRect rcMonitor;
-    GetMonitorRect(GetHWND() != nullptr ? GetHWND() : hCenterWindow, rcMonitor, rcArea);
+    GetMonitorRect(hCenterWindow != nullptr ? hCenterWindow : GetHWND(), rcMonitor, rcArea);
     if (hCenterWindow == nullptr) {
         rcCenter = rcArea;
     }
@@ -863,22 +863,27 @@ bool NativeWindow_Windows::CalculateCenterWindowPos(HWND hCenterWindow, int32_t&
         GetWindowRect(hCenterWindow, rcCenter);
     }
 
+    //屏幕编译留出空隙，避免出现贴边操作
+    UINT dpi = 96;
+    GetDpiForWindowWrapper(hCenterWindow != nullptr ? hCenterWindow : GetHWND(), dpi);
+    const int32_t snapThreshold = MulDiv(3, dpi, 96);
+
     // Find dialog's upper left based on rcCenter
     int32_t xLeft = rcCenter.CenterX() - nWindowWidth / 2;
     int32_t yTop = rcCenter.CenterY() - nWindowHeight / 2;
 
     // The dialog is outside the screen, move it inside
     if (xLeft < rcArea.left) {
-        xLeft = rcArea.left;
+        xLeft = rcArea.left + snapThreshold;
     }
     else if (xLeft + nWindowWidth > rcArea.right) {
-        xLeft = rcArea.right - nWindowWidth;
+        xLeft = rcArea.right - nWindowWidth - snapThreshold;
     }
     if (yTop < rcArea.top) {
-        yTop = rcArea.top;
+        yTop = rcArea.top + snapThreshold;
     }
     else if (yTop + nWindowHeight > rcArea.bottom) {
-        yTop = rcArea.bottom - nWindowHeight;
+        yTop = rcArea.bottom - nWindowHeight - snapThreshold;
     }
     xPos = xLeft;
     yPos = yTop;

--- a/duilib/Core/NativeWindow_Windows.cpp
+++ b/duilib/Core/NativeWindow_Windows.cpp
@@ -1225,6 +1225,22 @@ void NativeWindow_Windows::SetText(const DString& strText)
 #endif
 }
 
+DString NativeWindow_Windows::GetText() const
+{
+    ASSERT(::IsWindow(m_hWnd));
+    DString text;
+    int nLen = ::GetWindowTextLength(m_hWnd);
+    if (nLen > 0) {
+        std::vector<TCHAR> szText;
+        szText.resize((size_t)nLen + 2);
+        memset(szText.data(), 0, szText.size() * sizeof(TCHAR));
+        ::GetWindowText(m_hWnd, szText.data(), (int)szText.size() - 1);
+        DString localText = szText.data();
+        text = StringConvert::LocalToT(localText);
+    }
+    return text;
+}
+
 void NativeWindow_Windows::SetWindowMaximumSize(const UiSize& szMaxWindow)
 {
     m_szMaxWindow = szMaxWindow;

--- a/duilib/Core/NativeWindow_Windows.h
+++ b/duilib/Core/NativeWindow_Windows.h
@@ -275,6 +275,10 @@ public:
     */
     void SetText(const DString& strText);
 
+    /** 获取窗口标题栏文本
+    */
+    DString GetText() const;
+
     /** 设置窗口大小的最小值（宽度和高度，内部不按DPI调整大小，DPI自适应需要调用方来做）
     * @param [in] szMaxWindow 窗口的最大宽度和最小高度，如果值为0，表示不做限制
     */

--- a/duilib/Core/PlaceHolder.cpp
+++ b/duilib/Core/PlaceHolder.cpp
@@ -17,7 +17,9 @@ PlaceHolder::PlaceHolder(Window* pWindow) :
     m_verAlignType(kVerAlignTop),
     m_bFloat(false),
     m_bVisible(true),
+    m_bAncestorVisible(true),
     m_bEnabled(true),
+    m_bAncestorEnabled(true),
     m_bMouseEnabled(true),
     m_bKeyboardEnabled(true),
     m_bIsArranged(true),
@@ -112,31 +114,76 @@ void PlaceHolder::OnInit()
 
 void PlaceHolder::SetVisible(bool bVisible)
 {
+    bool bOldVisible = IsVisible();
     m_bVisible = bVisible;
+    bool bChanged = (bOldVisible != IsVisible());
+    OnSetVisible(bChanged);
+}
+
+bool PlaceHolder::IsVisible() const
+{
+    return m_bVisible && m_bAncestorVisible && IsVisibleInternal();
+}
+
+void PlaceHolder::SetAncestorVisible(bool bAncestorVisible)
+{
+    bool bOldVisible = IsVisible();
+    m_bAncestorVisible = bAncestorVisible;
+    bool bChanged = (bOldVisible != IsVisible());
+    OnSetVisible(bChanged);
+}
+
+bool PlaceHolder::IsAncestorVisible() const
+{
+    return m_bAncestorVisible;
 }
 
 void PlaceHolder::SetEnabled(bool bEnable)
 {
+    bool bOldEnabled = IsEnabled();
     m_bEnabled = bEnable;
+    bool bChanged = (bOldEnabled != IsEnabled());
+    OnSetEnabled(bChanged);
+}
+
+bool PlaceHolder::IsEnabled() const
+{
+    return m_bEnabled && m_bAncestorEnabled;
+}
+
+bool PlaceHolder::IsAncestorEnabled() const
+{
+    return m_bAncestorEnabled;
+}
+
+void PlaceHolder::SetAncestorEnabled(bool bAncestorEnable)
+{
+    bool bOldEnabled = IsEnabled();
+    m_bAncestorEnabled = bAncestorEnable;
+    bool bChanged = (bOldEnabled != IsEnabled());
+    OnSetEnabled(bChanged);
 }
 
 void PlaceHolder::SetMouseEnabled(bool bEnabled)
 {
+    bool bChanged = (m_bMouseEnabled != bEnabled);
     m_bMouseEnabled = bEnabled;
+    OnSetMouseEnabled(bChanged);
 }
 
 void PlaceHolder::SetKeyboardEnabled(bool bEnabled)
 {
+    bool bChanged = (m_bKeyboardEnabled != bEnabled);
     m_bKeyboardEnabled = bEnabled;
+    OnSetKeyboardEnabled(bChanged);
 }
 
 void PlaceHolder::SetFloat(bool bFloat)
 {
-    if (m_bFloat == bFloat) {
-        return;
+    if (m_bFloat != bFloat) {
+        m_bFloat = bFloat;
+        ArrangeAncestor();
     }
-    m_bFloat = bFloat;
-    ArrangeAncestor();
 }
 
 const UiFixedSize& PlaceHolder::GetFixedSize() const

--- a/duilib/Core/PlaceHolder.h
+++ b/duilib/Core/PlaceHolder.h
@@ -81,52 +81,71 @@ public:
     */
     bool IsInited() const;
 
-    /**@brief 设置该控件是否可见
+public:
+    /** 设置该控件是否可见
      */
-    virtual void SetVisible(bool bVisible);
+    void SetVisible(bool bVisible);
 
-    /**@brief 判断是否可见
+    /** 判断是否可见
      */
-    virtual bool IsVisible() const { return m_bVisible; }
+    bool IsVisible() const;
 
-    /** 检查控件是否可用
-     * @return 控件可用状态，返回 true 控件可用，否则为 false
+    /** 设置祖先控件是否可见
+    */
+    void SetAncestorVisible(bool bAncestorVisible);
+
+    /**@ 判断祖先是否可见
      */
-    virtual bool IsEnabled() const { return m_bEnabled; }
+    bool IsAncestorVisible() const;
 
     /** 设置控件可用状态
      * @param [in] bEnable 为 true 时控件可用，为 false 时控件为禁用状态则不可用
      */
-    virtual void SetEnabled(bool bEnable);
+    void SetEnabled(bool bEnable);
 
-    /** 检查控件是否响应鼠标事件
-     * @return 返回控件是否响应鼠标事件，返回 true 响应鼠标事件，false 为不响应
+    /** 检查控件是否可用
+     * @return 控件可用状态，返回 true 控件可用，否则为 false
      */
-    virtual bool IsMouseEnabled() const { return m_bMouseEnabled; }
+    bool IsEnabled() const;
+
+    /** 设置祖先控件可用状态
+     * @param [in] bEnable 为 true 时控件可用，为 false 时控件为禁用状态则不可用
+     */
+    void SetAncestorEnabled(bool bAncestorEnable);
+
+    /** 检查祖先控件是否可用
+     * @return 控件可用状态，返回 true 控件可用，否则为 false
+     */
+    bool IsAncestorEnabled() const;
 
     /** 设置控件是否响应鼠标事件
      * @param [in] bEnable 为 true 响应鼠标事件，为 false 时不响应鼠标事件
      */
-    virtual void SetMouseEnabled(bool bEnable);
+    void SetMouseEnabled(bool bEnable);
 
-    /** 检查控件是否响应键盘事件
-     * @return 返回控件是否响应键盘事件，返回 true 响应键盘事件，false 不响应键盘事件
+    /** 检查控件是否响应鼠标事件
+     * @return 返回控件是否响应鼠标事件，返回 true 响应鼠标事件，false 为不响应
      */
-    virtual bool IsKeyboardEnabled() const { return m_bKeyboardEnabled; }
+    bool IsMouseEnabled() const { return m_bMouseEnabled; }
 
     /** 设置控件是否响应键盘事件
      * @param [in] bEnable 为 true 响应键盘事件，为 false 时不响应键盘事件
      */
-    virtual void SetKeyboardEnabled(bool bEnable);
+    void SetKeyboardEnabled(bool bEnable);
 
-    /** 判断控件是否浮动状态，对应 xml 中 float 属性
+    /** 检查控件是否响应键盘事件
+     * @return 返回控件是否响应键盘事件，返回 true 响应键盘事件，false 不响应键盘事件
      */
-    bool IsFloat() const { return m_bFloat; }
+    bool IsKeyboardEnabled() const { return m_bKeyboardEnabled; }
 
     /** 设置控件是否浮动
      * @param [in] bFloat 设置为 true 为浮动，false 为不浮动
      */
     void SetFloat(bool bFloat);
+
+    /** 判断控件是否浮动状态，对应 xml 中 float 属性
+     */
+    bool IsFloat() const { return m_bFloat; }
 
     /** 获取与父控件的相对位置(仅当控件为浮动控件时有效)
     * @return 如果返回的cx和cy都是INT32_MIN，表示无效值，其他值表示有效值
@@ -392,8 +411,33 @@ public:
     const DpiManager& Dpi() const;
 
 protected:
+    /** 可见状态（供内部子类重写可见状态使用, 如果返回true代表可见，返回false表示不可见）
+    */
+    virtual bool IsVisibleInternal() const { return true; }
+
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) { UNUSED_VARIABLE(bChanged); }
+
+    /** 设置可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetEnabled(bool bChanged) { UNUSED_VARIABLE(bChanged); }
+
+    /** 设置鼠标可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetMouseEnabled(bool bChanged) { UNUSED_VARIABLE(bChanged); }
+
+    /** 设置键盘可用状态
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetKeyboardEnabled(bool bChanged) { UNUSED_VARIABLE(bChanged); }
+
+protected:
     /** 让自己重排
-     */
+    */
     virtual void ArrangeSelf();
 
     /** 执行初始化函数的事件（每个控件在初始化时，会调用该函数，并且只调用一次）
@@ -473,8 +517,14 @@ private:
     //是否可见
     bool m_bVisible;
 
+    //上级容器是否可见
+    bool m_bAncestorVisible;
+
     //控件的Enable状态（当为false的时候，不响应鼠标、键盘等输入消息）
     bool m_bEnabled;
+
+    //上级容器的Enable状态
+    bool m_bAncestorEnabled;
 
     //鼠标消息的Enable状态（当为false的时候，不响应鼠标消息）
     bool m_bMouseEnabled;

--- a/duilib/Core/ScrollBar.cpp
+++ b/duilib/Core/ScrollBar.cpp
@@ -175,10 +175,18 @@ void ScrollBar::ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale)
     BaseClass::ChangeDpiScale(nOldDpiScale, nNewDpiScale);
 }
 
-void ScrollBar::SetEnabled(bool bEnable)
+void ScrollBar::OnSetVisible(bool bChanged)
 {
-    BaseClass::SetEnabled(bEnable);
-    if( bEnable ) {
+    BaseClass::OnSetVisible(bChanged);
+    if (bChanged) {
+        ArrangeSelf();
+    }
+}
+
+void ScrollBar::OnSetEnabled(bool bChanged)
+{
+    BaseClass::OnSetEnabled(bChanged);
+    if(IsEnabled()) {
         m_uButton1State = kControlStateNormal;
         m_uButton2State = kControlStateNormal;
         m_uThumbState = kControlStateNormal;
@@ -188,6 +196,7 @@ void ScrollBar::SetEnabled(bool bEnable)
         m_uButton2State = kControlStateDisabled;
         m_uThumbState = kControlStateDisabled;
     }
+    Invalidate();
 }
 
 void ScrollBar::SetFocus()
@@ -197,15 +206,6 @@ void ScrollBar::SetFocus()
     }
     else {
         Control::SetFocus();
-    }
-}
-
-void ScrollBar::SetVisible(bool bVisible)
-{
-    bool v = BaseClass::IsVisible();
-    BaseClass::SetVisible(bVisible);
-    if( IsVisible() != v) {
-        ArrangeSelf();
     }
 }
 

--- a/duilib/Core/ScrollBar.h
+++ b/duilib/Core/ScrollBar.h
@@ -23,9 +23,7 @@ public:
 
     /// 重写父类方法，提供个性化功能，请参考父类声明
     virtual DString GetType() const override;
-    virtual void SetEnabled(bool bEnable = true) override;
     virtual void SetFocus() override;
-    virtual void SetVisible(bool bVisible) override;
     virtual bool ButtonUp(const EventArgs& msg) override;
     virtual bool HasHotState() override;
     virtual bool MouseEnter(const EventArgs& msg) override;
@@ -235,6 +233,17 @@ public:
     /** 设置关联横向滚动条的高度
     */
     void SetHScrollbarHeight(int32_t nHScrollbarHeight);
+
+protected:
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
+
+    /** 设置可用状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetEnabled(bool bChanged) override;
 
 private:
     void ScrollTimeHandle();

--- a/duilib/Core/Window.cpp
+++ b/duilib/Core/Window.cpp
@@ -2027,6 +2027,7 @@ void Window::OnButtonDown(EventType eventType, const UiPoint& pt, const NativeMs
            eventType == kEventMouseRDoubleClick ||
            eventType == kEventMouseMDoubleClick);
 
+    const bool bWindowFocused = IsWindowFocused();
     std::weak_ptr<WeakFlag> windowFlag = GetWeakFlag();    
     if ((eventType == kEventMouseButtonDown) || (eventType == kEventMouseButtonDown) || (eventType == kEventMouseButtonDown)) {
         SetCapture();
@@ -2045,6 +2046,7 @@ void Window::OnButtonDown(EventType eventType, const UiPoint& pt, const NativeMs
         ControlPtr pOldEventClick = m_pEventClick;
         m_pEventClick = pControl;
         bool bOldCheckSetWindowFocus = IsCheckSetWindowFocus();
+        SetCheckSetWindowFocus(false);
         pControl->SetFocus();
         if (windowFlag.expired()) {
             return;
@@ -2072,8 +2074,8 @@ void Window::OnButtonDown(EventType eventType, const UiPoint& pt, const NativeMs
             }
         }
     }
-    if (!windowFlag.expired()) {
-        //确保被点击的窗口有输入焦点
+    if (!bWindowFocused && !windowFlag.expired()) {
+        //确保被点击的窗口有输入焦点(解决CEF窗口模式下，输入焦点无法从页面切换到地址栏的问题)
         CheckSetWindowFocus();
     }
 }

--- a/duilib/Core/Window.cpp
+++ b/duilib/Core/Window.cpp
@@ -327,7 +327,7 @@ void Window::PreInitWindow()
     }
 
     //添加到全局管理器
-    GlobalManager::Instance().AddWindow(this);
+    GlobalManager::Instance().Windows().AddWindow(this);
 
     //解析窗口关联的XML文件
     if (m_windowBuilder == nullptr) {
@@ -416,7 +416,7 @@ void Window::OnFinalMessage()
 
 void Window::ClearWindow(bool bSendClose)
 {
-    bool bHasWindow = GlobalManager::Instance().HasWindow(this);
+    bool bHasWindow = GlobalManager::Instance().Windows().HasWindow(this);
     if (bSendClose && bHasWindow) {
         //发送关闭事件
         WPARAM wParam = (WPARAM)GetCloseParam();
@@ -428,7 +428,7 @@ void Window::ClearWindow(bool bSendClose)
     }
     
     //回收控件
-    GlobalManager::Instance().RemoveWindow(this);
+    GlobalManager::Instance().Windows().RemoveWindow(this);
     ReapObjects(GetRoot());
 
     Box* pRoot = m_pRoot.get();
@@ -2224,7 +2224,7 @@ void Window::OnFocusControlChanged()
 Window* Window::WindowFromPoint(const UiPoint& pt, bool bIgnoreChildWindow)
 {
     WindowBase* pWindow = WindowBaseFromPoint(pt, bIgnoreChildWindow);
-    if (!GlobalManager::Instance().HasWindowBase(pWindow)) {
+    if (!GlobalManager::Instance().Windows().HasWindowBase(pWindow)) {
         //不是本进程窗口时，不使用，避免跨进程的窗口时导致崩溃
         pWindow = nullptr;
     }

--- a/duilib/Core/WindowBase.cpp
+++ b/duilib/Core/WindowBase.cpp
@@ -716,7 +716,7 @@ void WindowBase::SetWindowMinimumSize(const UiSize& szMaxWindow, bool bNeedDpiSc
 
 const UiSize& WindowBase::GetWindowMinimumSize() const
 {
-    return NativeWnd()->GetWindowMaximumSize();
+    return NativeWnd()->GetWindowMinimumSize();
 }
 
 int32_t WindowBase::SetWindowHotKey(uint8_t wVirtualKeyCode, uint8_t wModifiers)

--- a/duilib/Core/WindowBase.h
+++ b/duilib/Core/WindowBase.h
@@ -2,6 +2,7 @@
 #define UI_CORE_WINDOW_BASE_H_
 
 #include "duilib/Core/INativeWindow.h"
+#include "duilib/Core/ControlPtrT.h"
 #include "duilib/Utils/FilePath.h"
 
 #if defined (DUILIB_BUILD_FOR_SDL)
@@ -263,7 +264,7 @@ public:
 
     /** 获取窗口标题栏文本
     */
-    const DString& GetText() const;
+    DString GetText() const;
 
     /** 根据语言列表中的文本 ID， 根据ID设置窗口标题栏文本
     * @param [in] strTextId 语言 ID，该 ID 必须在语言文件中存在
@@ -273,6 +274,18 @@ public:
     /** 获取窗口标题栏文本的文本ID
     */
     const DString& GetTextId() const;
+
+    /** 获取窗口ID
+    */
+    const DString& GetWindowId() const;
+
+    /** 设置窗口ID
+    */
+    void SetWindowId(const DString& windowId);
+
+    /** 获取窗口的Class名称
+    */
+    const DString& GetWindowClassName() const;
 
     /** 获取该窗口对应的DPI管理器
     */
@@ -1024,10 +1037,7 @@ private:
 
 private:
     //父窗口
-    WindowBase* m_pParentWindow;
-
-    //父窗口的WeakFlag
-    std::weak_ptr<WeakFlag> m_parentFlag;
+    ControlPtrT<WindowBase> m_pParentWindow;
 
     //该窗口消息过滤器列表
     std::vector<IUIMessageFilter*> m_aMessageFilters;
@@ -1037,10 +1047,13 @@ private:
 
 private:
     //窗口标题栏文本的文本ID
-    DString m_text;
-
-    //窗口标题栏文本的文本ID
     DString m_textId;
+
+    //窗口ID
+    DString m_windowId;
+
+    //窗口的Class名称
+    DString m_windowClassName;
 
     //窗口四边可拉伸范围信息
     UiRect m_rcSizeBox;

--- a/duilib/Core/WindowCreateParam.cpp
+++ b/duilib/Core/WindowCreateParam.cpp
@@ -16,17 +16,19 @@ WindowCreateParam::WindowCreateParam():
 {
 }
 
-WindowCreateParam::WindowCreateParam(const DString& windowTitle):
+WindowCreateParam::WindowCreateParam(const DString& windowTitle, const DString& windowId):
     WindowCreateParam()
 {
     m_windowTitle = windowTitle;
+    m_windowId = windowId;
 }
 
-WindowCreateParam::WindowCreateParam(const DString& windowTitle, bool bCenterWindow) :
+WindowCreateParam::WindowCreateParam(const DString& windowTitle, bool bCenterWindow, const DString& windowId) :
     WindowCreateParam()
 {
     m_windowTitle = windowTitle;
     m_bCenterWindow = bCenterWindow;
+    m_windowId = windowId;
 }
 
 } // namespace ui

--- a/duilib/Core/WindowCreateParam.h
+++ b/duilib/Core/WindowCreateParam.h
@@ -70,14 +70,16 @@ public:
 
     /** 提供窗口标题的构造函数
     * @param [in] windowTitle 窗口标题
+    * @param [in] windowId 窗口ID，如果为空，内部会生成一个窗口ID
     */
-    explicit WindowCreateParam(const DString& windowTitle);
+    explicit WindowCreateParam(const DString& windowTitle, const DString& windowId = _T(""));
 
     /** 提供窗口标题, 窗口居中的构造函数
     * @param [in] windowTitle 窗口标题
     * @param [in] bCenterWindow 窗口初始位置居中显示
+    * @param [in] windowId 窗口ID，如果为空，内部会生成一个窗口ID
     */
-    WindowCreateParam(const DString& windowTitle, bool bCenterWindow);
+    WindowCreateParam(const DString& windowTitle, bool bCenterWindow, const DString& windowId = _T(""));
 
 public:
     /** 平台相关数据（可选参数，如不填写则使用默认值：nullptr）
@@ -105,6 +107,10 @@ public:
     /** 窗口的标题（可选参数，默认为空）
     */
     DString m_windowTitle;
+
+    /** 窗口ID（可以为空，如果为空的话，内部会自动生成一个唯一ID）
+    */
+    DString m_windowId;
 
 public:
     /** 窗口的左上角X坐标(如果不设置，则使用默认值)

--- a/duilib/Core/WindowManager.cpp
+++ b/duilib/Core/WindowManager.cpp
@@ -1,0 +1,130 @@
+#include "WindowManager.h"
+#include "duilib/Core/Window.h"
+#include "duilib/Core/GlobalManager.h"
+#include <set>
+
+namespace ui 
+{
+WindowManager::WindowManager()
+{
+}
+
+WindowManager::~WindowManager()
+{
+}
+
+void WindowManager::AddWindow(Window* pWindow)
+{
+    GlobalManager::Instance().AssertUIThread();
+    ASSERT(pWindow != nullptr);
+    if (pWindow != nullptr) {
+        auto iter = std::find(m_windowList.begin(), m_windowList.end(), pWindow);
+        if (iter != m_windowList.end()) {
+            m_windowList.erase(iter);
+        }
+        m_windowList.push_back(WindowPtr(pWindow));
+    }
+
+#ifdef _DEBUG    
+    if (1) {
+        //校验窗口ID是否重复
+        std::set<DString> windowIdSet;
+        for (auto iter = m_windowList.rbegin(); iter != m_windowList.rend(); ++iter) {
+            if (iter->get() != nullptr) {
+                ASSERT(!iter->get()->GetWindowClassName().empty());
+                DString windowId = iter->get()->GetWindowId();
+                ASSERT(!windowId.empty());
+                if (!windowIdSet.empty()) {
+                    ASSERT(windowIdSet.find(windowId) == windowIdSet.end());
+                }
+                windowIdSet.insert(windowId);
+            }
+        }
+    }
+#endif
+}
+
+void WindowManager::RemoveWindow(Window* pWindow)
+{
+    GlobalManager::Instance().AssertUIThread();
+    ASSERT(pWindow != nullptr);
+    if (pWindow != nullptr) {
+        auto iter = std::find(m_windowList.begin(), m_windowList.end(), pWindow);
+        if (iter != m_windowList.end()) {
+            m_windowList.erase(iter);
+        }
+    }
+}
+
+bool WindowManager::HasWindow(Window* pWindow) const
+{
+    GlobalManager::Instance().AssertUIThread();
+    if (pWindow != nullptr) {
+        for (auto iter = m_windowList.begin(); iter != m_windowList.end(); ++iter) {
+            if (iter->get() == pWindow) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool WindowManager::HasWindowBase(WindowBase* pWindowBase) const
+{
+    GlobalManager::Instance().AssertUIThread();
+    if (pWindowBase != nullptr) {
+        for (auto iter = m_windowList.begin(); iter != m_windowList.end(); ++iter) {
+            if (iter->get() == pWindowBase) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+std::vector<WindowPtr> WindowManager::GetAllWindowList() const
+{
+    GlobalManager::Instance().AssertUIThread();
+    std::vector<WindowPtr> windowList;
+    for (auto iter = m_windowList.begin(); iter != m_windowList.end(); ++iter) {
+        if (iter->get() != nullptr) {
+            windowList.push_back(*iter);
+        }
+    }
+    return windowList;
+}
+
+std::vector<WindowPtr> WindowManager::GetAllWindowList(const DString& windowClassName) const
+{
+    GlobalManager::Instance().AssertUIThread();
+    std::vector<WindowPtr> windowList;
+    for (auto iter = m_windowList.begin(); iter != m_windowList.end(); ++iter) {
+        if (iter->get() != nullptr) {
+            if (windowClassName == iter->get()->GetWindowClassName()) {
+                windowList.push_back(*iter);
+            }
+        }
+    }
+    return windowList;
+}
+
+WindowPtr WindowManager::GetWindowById(const DString& windowId) const
+{
+    GlobalManager::Instance().AssertUIThread();
+    WindowPtr pWindow;
+    for (auto iter = m_windowList.begin(); iter != m_windowList.end(); ++iter) {
+        if (iter->get() != nullptr) {
+            if (windowId == iter->get()->GetWindowId()) {
+                pWindow = iter->get();
+            }
+        }
+    }
+    return pWindow;
+}
+
+void WindowManager::Clear()
+{
+    m_windowList.clear();
+}
+
+} //namespace ui

--- a/duilib/Core/WindowManager.h
+++ b/duilib/Core/WindowManager.h
@@ -1,0 +1,66 @@
+#ifndef UI_CORE_WINDOW_MANAGER_H_
+#define UI_CORE_WINDOW_MANAGER_H_
+
+#include "duilib/Core/UiTypes.h"
+#include "duilib/Core/ControlPtrT.h"
+
+namespace ui 
+{
+class Window;
+class WindowBase;
+
+/** 窗口管理器，用于管理所有窗口的生命周期
+ */
+class UILIB_API WindowManager
+{
+public:
+    WindowManager();
+    ~WindowManager();
+    WindowManager(const WindowManager&) = delete;
+    WindowManager& operator = (const WindowManager&) = delete;
+
+public:
+    /** 添加一个窗口接口（主要用于换肤、切换语言之后的重绘、资源同步等操作）
+    * @param [in] pWindow 窗口的接口
+    */
+    void AddWindow(Window* pWindow);
+
+    /** 移除一个窗口
+    * @param [in] pWindow 窗口的接口
+    */
+    void RemoveWindow(Window* pWindow);
+
+    /** 判断当前是否含有窗口
+    * @param [in] pWindow 窗口的接口
+    */
+    bool HasWindow(Window* pWindow) const;
+    bool HasWindowBase(WindowBase* pWindowBase) const;
+
+    /** 获取所有窗口列表
+    */
+    std::vector<WindowPtr> GetAllWindowList() const;
+
+    /** 获取指定窗口类下的所有窗口
+    * @param [in] windowClassName 创建窗口时传入的窗口类名
+    */
+    std::vector<WindowPtr> GetAllWindowList(const DString& windowClassName) const;
+
+    /** 获取指定窗口ID对应的窗口
+    * @param [in] windowId 窗口ID, 理论上该Id是唯一的
+    * @return 返回该窗口ID对应的窗口，如果存在多个，则返回第一个匹配的窗口
+    */
+    WindowPtr GetWindowById(const DString& windowId) const;
+
+    /** 清空
+    */
+    void Clear();
+
+private:
+    /** 窗口列表
+    */
+    std::vector<WindowPtr> m_windowList;
+};
+
+} //namespace ui 
+
+#endif //UI_CORE_WINDOW_MANAGER_H_

--- a/duilib/WebView2/WebView2Control.cpp
+++ b/duilib/WebView2/WebView2Control.cpp
@@ -118,10 +118,10 @@ bool WebView2Control::OnKillFocus(const EventArgs& msg)
     return bRet;
 }
 
-void WebView2Control::SetVisible(bool bVisible)
+void WebView2Control::OnSetVisible(bool bChanged)
 {
-    BaseClass::SetVisible(bVisible);
-    m_pImpl->SetVisible(bVisible);
+    BaseClass::OnSetVisible(bChanged);
+    m_pImpl->SetVisible(IsVisible());
 }
 
 void WebView2Control::SetWindow(Window* pWindow)

--- a/duilib/WebView2/WebView2Control.h
+++ b/duilib/WebView2/WebView2Control.h
@@ -302,7 +302,6 @@ public:
     virtual void SetPos(UiRect rc) override;
     virtual bool OnSetFocus(const EventArgs& msg) override;
     virtual bool OnKillFocus(const EventArgs& msg) override;
-    virtual void SetVisible(bool bVisible) override;
     virtual void SetWindow(Window* pWindow) override;
 
     /** 设置是否允许F12快捷键(开发者工具)
@@ -336,6 +335,12 @@ public:
     /** 将网页保存为一张图片, 图片大小与控件大小相同
     */
     std::shared_ptr<IBitmap> MakeImageSnapshot();
+
+protected:
+    /** 设置可见状态事件
+    * @param [in] bChanged true表示状态发生变化，false表示状态未发生变化
+    */
+    virtual void OnSetVisible(bool bChanged) override;
 
 private:
     // PIMPL实现

--- a/duilib/duilib.vcxproj
+++ b/duilib/duilib.vcxproj
@@ -350,6 +350,7 @@
     <ClCompile Include="Core\WindowCreateParam.cpp" />
     <ClCompile Include="Core\WindowDropTarget_SDL.cpp" />
     <ClCompile Include="Core\WindowDropTarget_Windows.cpp" />
+    <ClCompile Include="Core\WindowManager.cpp" />
     <ClCompile Include="Core\ZipManager.cpp" />
     <ClCompile Include="Core\ZipStreamIO.cpp" />
     <ClCompile Include="duilib.cpp" />
@@ -627,6 +628,7 @@
     <ClInclude Include="Core\WindowCreateParam.h" />
     <ClInclude Include="Core\WindowDropTarget_SDL.h" />
     <ClInclude Include="Core\WindowDropTarget_Windows.h" />
+    <ClInclude Include="Core\WindowManager.h" />
     <ClInclude Include="Core\WindowMessage.h" />
     <ClInclude Include="Core\ZipManager.h" />
     <ClInclude Include="Core\ZipStreamIO.h" />

--- a/duilib/duilib.vcxproj.filters
+++ b/duilib/duilib.vcxproj.filters
@@ -711,6 +711,9 @@
     <ClCompile Include="Core\ControlDropTargetUtils.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="Core\WindowManager.cpp">
+      <Filter>Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Animation\AnimationManager.h">
@@ -1494,6 +1497,9 @@
       <Filter>Core\Windows</Filter>
     </ClInclude>
     <ClInclude Include="Core\ControlDropTargetUtils.h">
+      <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="Core\WindowManager.h">
       <Filter>Core</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
父组件在被显示的时候，会导致子组件visible也为ture（#254）：
（1）修改Visible和Enabled状态的实现逻辑，将父控件和子控件的可见状态/禁用状态分离，不再逐级同步，从而避免该Issue提到的问题。
（2）缺陷修复：修复DateTime控件无法激活编辑的问题（设置焦点的逻辑有缺陷导致的问题）。
（3）RichEdit控件：修复HideSelection状态异常的问题（当弹出右键菜单后，状态异常，导致选择的文本不显示）。
（4）ListCtrl控件：Report类型时，如果设置置顶项，应优先查找置顶项（Bug修复）
（5）ListCtrl控件：修复列表风格切换后，再重新切回Report视图后，界面元素不刷新的问题（Bug修复：界面的刷新回调函数未正确注册导致）