### PR TITLE
修复缺陷（多语版切换语言时，未正确更新布局）：关于控件属性width为auto时，切换语言，控件不会重绘的问题。 #314

### DIFF
--- a/bin/resources/themes/default/MultiLang/lang_menu.xml
+++ b/bin/resources/themes/default/MultiLang/lang_menu.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Window shadow_type="menu_round" shadow_attached="true" layered_window="true">
-    <VListBox class="menu">       
+    <VListBox class="menu" padding="0,0,0,6">       
         <!-- 在菜单中插入普通控件，实现特定功能 -->
         <HBox class="menu_split_box" height="36" width="256">
-            <Label class="menu_text" textid="MULTI_LANG_SELECT_LANGUAGE" textpadding="0,0,6,0"/>     
+            <Label class="menu_text" textid="MULTI_LANG_SELECT_LANGUAGE" text_padding="0,0,6,0"/>     
         </HBox>
         
         <!-- 菜单项之间的分割线 -->

--- a/duilib/Control/Label.h
+++ b/duilib/Control/Label.h
@@ -57,6 +57,10 @@ public:
     */
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
 
+    /** 语言发生变化，刷新界面文字显示相关的内容
+    */
+    virtual void OnLanguageChanged() override;
+
     /** 恢复默认的文本样式
     * @param [in] bRedraw true表示重绘，false表示不重绘
     */
@@ -497,6 +501,15 @@ void LabelTemplate<InheritType>::ChangeDpiScale(uint32_t nOldDpiScale, uint32_t 
     SetWordSpacing(fWordSpacing, false);
 
     BaseClass::ChangeDpiScale(nOldDpiScale, nNewDpiScale);
+}
+
+template<typename InheritType>
+void LabelTemplate<InheritType>::OnLanguageChanged()
+{
+    BaseClass::OnLanguageChanged();
+    //语言发生变化，字符串长度可能发生了变化，需要重新计算布局，更新ToolTip数据
+    this->RelayoutOrRedraw();
+    CheckShowToolTip();
 }
 
 template<typename InheritType>

--- a/duilib/Control/RichText.cpp
+++ b/duilib/Control/RichText.cpp
@@ -136,12 +136,19 @@ void RichText::ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale)
     BaseClass::ChangeDpiScale(nOldDpiScale, nNewDpiScale);
 }
 
+void RichText::OnLanguageChanged()
+{
+    BaseClass::OnLanguageChanged();
+    Redraw();
+}
+
 void RichText::Redraw()
 {
     //重新绘制
     m_textData.clear();
     m_spDrawRichTextCache.reset();
     Invalidate();
+    RelayoutOrRedraw();
 }
 
 uint16_t RichText::GetTextStyle() const

--- a/duilib/Control/RichText.h
+++ b/duilib/Control/RichText.h
@@ -86,6 +86,10 @@ public:
     */
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
 
+    /** 语言发生变化，刷新界面文字显示相关的内容
+    */
+    virtual void OnLanguageChanged() override;
+
     /** 计算文本区域大小（宽和高）
      *  @param [in] szAvailable 可用大小，不包含内边距，不包含外边距
      *  @return 控件的文本估算大小，包含内边距(Box)，不包含外边距

--- a/duilib/Core/Box.cpp
+++ b/duilib/Core/Box.cpp
@@ -74,6 +74,17 @@ void Box::ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale)
     }
 }
 
+void Box::OnLanguageChanged()
+{
+    BaseClass::OnLanguageChanged();
+    for (auto pControl : m_items) {
+        ASSERT(pControl != nullptr);
+        if (pControl != nullptr) {
+            pControl->OnLanguageChanged();
+        }
+    }
+}
+
 void Box::SetParent(Box* pParent)
 {
     Control::SetParent(pParent);
@@ -82,7 +93,7 @@ void Box::SetParent(Box* pParent)
         if (pControl != nullptr) {
             pControl->SetParent(this);
         }
-    }    
+    }
 }
 
 void Box::SetWindow(Window* pWindow)

--- a/duilib/Core/Box.h
+++ b/duilib/Core/Box.h
@@ -68,6 +68,10 @@ public:
     */
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
 
+    /** 语言发生变化，刷新界面文字显示相关的内容
+    */
+    virtual void OnLanguageChanged() override;
+
 public:
     /** @name 操作子控件(item)相关的方法
     * @{

--- a/duilib/Core/Control.cpp
+++ b/duilib/Core/Control.cpp
@@ -747,6 +747,12 @@ void Control::ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale)
     SetReEstimateSize(true);
 }
 
+void Control::OnLanguageChanged()
+{
+    RelayoutOrRedraw();
+    Invalidate();
+}
+
 void Control::SetClass(const DString& strClass)
 {
     if (strClass.empty()) {

--- a/duilib/Core/Control.h
+++ b/duilib/Core/Control.h
@@ -852,6 +852,10 @@ public:
     */
     virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale);
 
+    /** 语言发生变化，刷新界面文字显示相关的内容
+    */
+    virtual void OnLanguageChanged();
+
 public:
     /** 监听控件所有事件
      * @param[in] callback 事件处理的回调函数，请参考 EventCallback 声明

--- a/duilib/Core/GlobalManager.cpp
+++ b/duilib/Core/GlobalManager.cpp
@@ -488,7 +488,8 @@ bool GlobalManager::ReloadLanguage(const FilePath& languagePath,
                 pWindow->SetTextId(pWindow->GetTextId());
             }
             if (pBox != nullptr) {
-                pBox->Invalidate();
+                pBox->OnLanguageChanged();
+                pBox->SetPos(pBox->GetPos());
             }
         }
     }


### PR DESCRIPTION
修复缺陷（多语版切换语言时，未正确更新布局）：关于控件属性width为auto时，切换语言，控件不会重绘的问题。 #314
