### PR TITLE
imageinfo延时释放机制建议做成可配或更为友好的情况 #315

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
     <tr><td align="left">20. Label文本显示控件的功能加强：对文本齐方式新增加"两端对齐"，新增对竖排文本的支持（文本绘制方向从上到下，从右到左），新增支持设置行间距和设置字间距</td></tr>
     <tr><td align="left">21. Control控件支持全屏显示（通过调用新增加的Window::SetFullscreenControl函数实现该功能），CEF控件和WebView2控件支持F11切换页面全屏</td></tr>
     <tr>
-        <td rowspan="20">新增控件</td>
+        <td rowspan="21">新增控件</td>
         <td align="left">1. GroupBox：分组容器</td>
     </tr>
     <tr><td align="left">2. HotKey：热键控件</td></tr>
@@ -100,6 +100,7 @@
     <tr><td align="left">18. GridBox/GridScrollBox：基于网格布局的控件</td></tr>
     <tr><td align="left">19. HFlowBox/VFlowBox/HFlowScrollBox/VFlowScrollBox：基于水平流式布局和垂直流式布局的控件</td></tr>
     <tr><td align="left">20. MenuBar：菜单栏控件</td></tr>
+    <tr><td align="left">21. IconControl/BitmapControl：用户显示基于内存的小图标和位图数据</td></tr>
     <tr>
         <td rowspan="3">性能优化</td>
         <td align="left">1. 优化了Control及子控件的内存占用，在界面元素较多的时候，内存占有率有大幅降低</td>

--- a/bin/resources/themes/default/render/page_bitmap_control.xml
+++ b/bin/resources/themes/default/render/page_bitmap_control.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Window>
+    <Class name="bitmap_control_image" width="200" height="200" border_size="1" border_color="green" />
+    <Class name="bitmap_control_text" width="200" height="auto" multi_line="true" replace_newline="true" text_align="left,vcenter" />
+    <Class name="bitmap_control_case" width="200" height="auto" multi_line="true" replace_newline="true" text_align="hcenter,vcenter" />
+    <HFlowScrollBox width="auto" height="auto" child_margin_x="2" child_margin_y="2" padding="2,2,2,2">
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png"/>
+            <Label class="bitmap_control_case" text="用例编号（1.1）"/>
+            <Label class="bitmap_control_text" text="默认:大区域" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="100" height="100" bitmap_file="render/autumn.png"/>
+            <Label class="bitmap_control_case" text="用例编号（1.1）"/>
+            <Label class="bitmap_control_text" text="默认:小区域" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="auto" height="auto" bitmap_file="render/autumn.png"/>
+            <Label class="bitmap_control_case" text="用例编号（1.1）"/>
+            <Label class="bitmap_control_text" text="默认:auto" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_halign="left" bitmap_valign="top"/>
+            <Label class="bitmap_control_case" text="用例编号（1.2）"/>
+            <Label class="bitmap_control_text" text="bitmap_halign='left'\nbitmap_valign='top'"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_halign="center" bitmap_valign="center"/>
+            <Label class="bitmap_control_case" text="用例编号（1.3）"/>
+            <Label class="bitmap_control_text" text="bitmap_halign='center'\nbitmap_valign='center'"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_halign="right" bitmap_valign="bottom"/>
+            <Label class="bitmap_control_case" text="用例编号（1.4）"/>
+            <Label class="bitmap_control_text" text="bitmap_halign='right'\nbitmap_valign='bottom'"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_halign="center" bitmap_valign="center" bitmap_alpha="128"/>
+            <Label class="bitmap_control_case" text="用例编号（1.5）"/>
+            <Label class="bitmap_control_text" text="bitmap_alpha='128'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_halign="center" bitmap_valign="center" bitmap_margin="10,20,40,60"/>
+            <Label class="bitmap_control_case" text="用例编号（1.6）"/>
+            <Label class="bitmap_control_text" text="bitmap_margin='10,20,40,60'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_stretch="true"/>
+            <Label class="bitmap_control_case" text="用例编号（1.7）"/>
+            <Label class="bitmap_control_text" text="bitmap_stretch='true'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_adaptive_dest_rect="true"/>
+            <Label class="bitmap_control_case" text="用例编号（1.8）"/>
+            <Label class="bitmap_control_text" text="bitmap_adaptive_dest_rect='true'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="160" height="160" bitmap_file="render/autumn.png" bitmap_adaptive_dest_rect="true"/>
+            <Label class="bitmap_control_case" text="用例编号（1.9）"/>
+            <Label class="bitmap_control_text" text="bitmap_adaptive_dest_rect='true'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="160" height="160" bitmap_file="render/autumn.png" bitmap_adaptive_dest_rect="true" bitmap_halign="center"/>
+            <Label class="bitmap_control_case" text="用例编号（1.10）"/>
+            <Label class="bitmap_control_text" text="bitmap_adaptive_dest_rect='true'\nbitmap_halign='center'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="160" height="160" bitmap_file="render/autumn.png" bitmap_adaptive_dest_rect="true" bitmap_halign="right"/>
+            <Label class="bitmap_control_case" text="用例编号（1.11）"/>
+            <Label class="bitmap_control_text" text="bitmap_adaptive_dest_rect='true'\nbitmap_halign='right'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_src="80,80,160,160"/>
+            <Label class="bitmap_control_case" text="用例编号（1.12）"/>
+            <Label class="bitmap_control_text" text="bitmap_src='80,80,160,160'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="auto" height="auto" bitmap_file="render/autumn.png" bitmap_src="80,80,160,160"/>
+            <Label class="bitmap_control_case" text="用例编号（1.12）"/>
+            <Label class="bitmap_control_text" text="bitmap_src='80,80,160,160' auto" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" bitmap_file="render/autumn.png" bitmap_dest="80,80,160,160"/>
+            <Label class="bitmap_control_case" text="用例编号（1.13）"/>
+            <Label class="bitmap_control_text" text="bitmap_dest='80,80,160,160'" text_align="hcenter,vcenter"/>
+        </VBox>
+        <VBox width="auto" height="auto">
+            <BitmapControl class="bitmap_control_image" width="auto" height="auto" bitmap_file="render/autumn.png" bitmap_dest="80,80,160,160"/>
+            <Label class="bitmap_control_case" text="用例编号（1.13）"/>
+            <Label class="bitmap_control_text" text="bitmap_dest='80,80,160,160' auto" text_align="hcenter,vcenter"/>
+        </VBox>
+    </HFlowScrollBox>
+</Window>

--- a/bin/resources/themes/default/render/render.xml
+++ b/bin/resources/themes/default/render/render.xml
@@ -34,6 +34,7 @@
                 <TabCtrlItem class="tab_ctrl_item" title="BoxShadow" close_button_class="" tab_box_item_index="7"/>                
                 <TabCtrlItem class="tab_ctrl_item" title="属性页" close_button_class="" tab_box_item_index="8"/>
                 <TabCtrlItem class="tab_ctrl_item" title="窗口阴影" close_button_class="" tab_box_item_index="9"/>
+                <TabCtrlItem class="tab_ctrl_item" title="位图控件" close_button_class="" tab_box_item_index="10"/>
             </TabCtrl>
             <TabBox name="main_view_tab" bkcolor="white" fadeswitch="true" selected_id="0">
                 <VBox name="main_view_page_00">
@@ -74,6 +75,10 @@
                 <VBox name="main_view_page_09">
                     <Label text="页面9：窗口阴影测试"/>
                     <Include src="page_window_shadow.xml"/>
+                </VBox>
+                <VBox name="main_view_page_10">
+                    <Label text="页面10：位图控件测试"/>
+                    <Include src="page_bitmap_control.xml"/>
                 </VBox> 
             </TabBox>
         </VBox>

--- a/docs/Control.md
+++ b/docs/Control.md
@@ -692,6 +692,21 @@ WebView2Control 控件继承了 `Control` 属性，更多可用属性请参考`C
 ## IconControl的属性
 IconControl 控件继承了 `Control` 属性，更多可用属性请参考`Control`的属性
 
+## BitmapControl的属性
+| 属性名称 | 默认值 | 参数类型 | 用途 |
+| :--- | :--- | :--- | :--- |
+| bitmap_halign  | left | string | 图片的水平对齐方式，可取值: "left"、"center"、"right" |
+| bitmap_valign  | top | string | 图片的垂直对齐方式，可取值: "top"、"center"、"bottom" |
+| bitmap_alpha  | 255 | int | 图片绘制时的透明度，可取值: 0 - 255 |
+| bitmap_dest  |  | rect | 图片绘制目标区域位置和大小(相对于控件区域的位置)|
+| bitmap_src  |  | rect | 图片绘制源区域位置和大小|
+| bitmap_margin  |  | rect | 绘制目标区域中的外边距(如果指定了dest值，此值无效)|
+| bitmap_adaptive_dest_rect  | false | bool | 绘制时是否自动适应目标区域（等比例缩放图片）|
+| bitmap_stretch  | false | bool | 绘制时是否拉伸绘制图片（与IsAdaptiveDestRect()互斥，优先级低于IsAdaptiveDestRect()）|
+| bitmap_multi_thread  | true | bool | 是否支持多线程操作位图数据（如果无调用，则默认为true，默认是支持多线程操作位图数据的）|
+
+BitmapControl 控件继承了 `Box` 属性，更多可用属性请参考`Box`的属性
+
 ## AddressBar的属性
 | 属性名称 | 默认值 | 参数类型 | 用途 |
 | :--- | :--- | :--- | :--- |

--- a/duilib/Control/BitmapControl.cpp
+++ b/duilib/Control/BitmapControl.cpp
@@ -1,0 +1,708 @@
+#include "BitmapControl.h"
+#include "duilib/Render/IRender.h"
+#include "duilib/Core/GlobalManager.h"
+#include "duilib/Utils/AttributeUtil.h"
+#include "duilib/Utils/PerformanceUtil.h"
+#include "duilib/Utils/FileUtil.h"
+#include "duilib/Image/ImageAttribute.h"
+
+namespace ui
+{
+
+BitmapControl::BitmapControl(Window* pWindow):
+    Box(pWindow),
+    m_hAlignType(HorAlignType::kAlignLeft),
+    m_vAlignType(VerAlignType::kAlignTop),
+    m_nBitmapAlpha(255),
+    m_bAdaptiveDestRect(false),
+    m_bStretchedDrawing(false),
+    m_bSupportMultiThread(true)
+{
+}
+
+BitmapControl::~BitmapControl()
+{
+    m_pBitmap.reset();
+}
+
+DString BitmapControl::GetType() const { return DUI_CTR_BITMAP_CONTROL; }
+
+void BitmapControl::SetAttribute(const DString& strName, const DString& strValue)
+{
+    if (strName == _T("bitmap_halign")) {
+        ASSERT((strValue == _T("left")) || (strValue == _T("center")) || (strValue == _T("right")));
+        if (strValue == _T("center")) {
+            SetBitmapHAlignType(HorAlignType::kAlignCenter);
+        }
+        else if (strValue == _T("right")) {
+            SetBitmapHAlignType(HorAlignType::kAlignRight);
+        }
+        else {
+            SetBitmapHAlignType(HorAlignType::kAlignLeft);
+        }
+    }
+    else if (strName == _T("bitmap_valign")) {
+        ASSERT((strValue == _T("top")) || (strValue == _T("center")) || (strValue == _T("bottom")));
+        if (strValue == _T("center")) {
+            SetBitmapVAlignType(VerAlignType::kAlignCenter);
+        }
+        else if (strValue == _T("bottom")) {
+            SetBitmapVAlignType(VerAlignType::kAlignBottom);
+        }
+        else {
+            SetBitmapVAlignType(VerAlignType::kAlignTop);
+        }
+    }
+    else if (strName == _T("bitmap_alpha")) {
+        SetBitmapAlpha((uint8_t)StringUtil::StringToInt32(strValue));
+    }
+    else if (strName == _T("bitmap_dest")) {
+        UiRect rcDest;
+        DString::value_type* pstr = nullptr;
+        rcDest.left = StringUtil::StringToInt32(strValue.c_str(), &pstr, 10); ASSERT(pstr);
+        AttributeUtil::SkipSepChar(pstr);
+        if (*pstr != _T('\0')) {
+            rcDest.top = StringUtil::StringToInt32(pstr, &pstr, 10); ASSERT(pstr);
+            AttributeUtil::SkipSepChar(pstr);
+        }
+        if (*pstr != _T('\0')) {
+            rcDest.right = StringUtil::StringToInt32(pstr, &pstr, 10); ASSERT(pstr);
+            AttributeUtil::SkipSepChar(pstr);
+        }
+        if (*pstr != _T('\0')) {
+            rcDest.bottom = StringUtil::StringToInt32(pstr, &pstr, 10); ASSERT(pstr);
+        }
+        SetBitmapDest(rcDest, true);
+    }
+    else if (strName == _T("bitmap_src")) {
+        UiRect rcSource;
+        AttributeUtil::ParseRectValue(strValue.c_str(), rcSource);
+        rcSource.left = std::max(rcSource.left, 0);
+        rcSource.top = std::max(rcSource.top, 0);
+        SetBitmapSource(rcSource, true);
+    }
+    else if (strName == _T("bitmap_margin")) {
+        UiMargin rcMargin;
+        AttributeUtil::ParseMarginValue(strValue.c_str(), rcMargin);
+        SetBitmapMargin(rcMargin, true);
+    }
+    else if (strName == _T("bitmap_adaptive_dest_rect")) {
+        SetAdaptiveDestRect(strValue == _T("true"));
+    }
+    else if (strName == _T("bitmap_stretch")) {
+        SetStretchedDrawing(strValue == _T("true"));
+    }
+    else if (strName == _T("bitmap_multi_thread")) {
+        SetSupportMultiThread(strValue == _T("true"));
+    }
+    else if (strName == _T("bitmap_file")) {
+        //设置关联的图片文件：主要用于测试
+        m_bitmapFile = strValue;
+        if (m_pBitmap != nullptr) {
+            m_pBitmap.reset();
+            CheckLoadBitmapFile();
+        }
+    }
+    else {
+        BaseClass::SetAttribute(strName, strValue);
+    }
+}
+
+UiSize BitmapControl::EstimateImage(UiSize szAvailable, EstimateImageType estImageType)
+{
+    UiSize estSize = BaseClass::EstimateImage(szAvailable, estImageType);
+
+    //按需加载指定的图片
+    CheckLoadBitmapFile();
+
+    int32_t nImageInfoWidth = 0;
+    int32_t nImageInfoHeight = 0;
+    GetBitmapSize(nImageInfoWidth, nImageInfoHeight);
+    if ((nImageInfoWidth <= 0) || (nImageInfoHeight <= 0)) {
+        //没有图像数据
+        return estSize;
+    }
+
+    //控件自身的内边距
+    const UiPadding rcControlPadding = GetControlPadding();
+    UiRect rcDest;
+    bool hasDestAttr = false;
+    if (m_rcDest != nullptr) {
+        //使用配置中指定的目标区域（已按配置做好DPI自适应）：优先作为图片大小的依据
+        rcDest = *m_rcDest;
+        if (rcDest.left < 0) {
+            rcDest.left = 0;
+        }
+        if (rcDest.top < 0) {
+            rcDest.top = 0;
+        }
+        if (rcDest.right <= rcDest.left) {
+            rcDest.right = rcDest.left + nImageInfoWidth;
+        }
+        if (rcDest.bottom <= rcDest.top) {
+            rcDest.bottom = rcDest.top + nImageInfoHeight;
+        }
+        hasDestAttr = true;
+    }
+    UiRect rcSource;
+    if (m_rcSource != nullptr) {
+        rcSource = *m_rcSource;
+    }
+    if (rcSource.right > (int32_t)nImageInfoWidth) {
+        rcSource.right = (int32_t)nImageInfoWidth;
+    }
+    if (rcSource.bottom > (int32_t)nImageInfoHeight) {
+        rcSource.bottom = (int32_t)nImageInfoHeight;
+    }
+
+    UiSize imageSize;
+    if (rcDest.Width() > 0) {
+        //以0为基点，right为边界
+        imageSize.cx = rcDest.right;
+    }
+    else if (rcSource.Width() > 0) {
+        imageSize.cx = rcSource.Width();
+    }
+    else {
+        imageSize.cx = nImageInfoWidth;
+    }
+
+    if (rcDest.Height() > 0) {
+        //以0为基点，bottom为边界
+        imageSize.cy = rcDest.bottom;
+    }
+    else if (rcSource.Height() > 0) {
+        imageSize.cy = rcSource.Height();
+    }
+    else {
+        imageSize.cy = nImageInfoHeight;
+    }
+
+    if (!hasDestAttr) {
+        //如果没有rcDest属性，则需要增加图片的外边距（图片自身的外边距属性）
+        UiMargin rcImageMargin;
+        if (m_rcMargin != nullptr) {
+            rcImageMargin = *m_rcMargin;
+        }
+        imageSize.cx += (rcImageMargin.left + rcImageMargin.right);
+        imageSize.cy += (rcImageMargin.top + rcImageMargin.bottom);
+    }
+    if (m_bAdaptiveDestRect) {
+        //自动适应目标区域（等比例缩放图片）：根据图片大小，调整绘制区域
+        const int32_t nImageWidth = rcSource.Width();
+        const int32_t nImageHeight = rcSource.Height();
+        UiRect rcControlDest = UiRect(0, 0,
+                                      szAvailable.cx - rcControlPadding.left - rcControlPadding.right,
+                                      szAvailable.cy - rcControlPadding.top - rcControlPadding.bottom);
+        rcControlDest.Validate();
+        if (rcControlDest.Width() > 0 && rcControlDest.Height() > 0) {
+            DString hAlign = _T("left");
+            if (m_hAlignType == HorAlignType::kAlignCenter) {
+                hAlign = _T("center");
+            }
+            else if (m_hAlignType == HorAlignType::kAlignRight) {
+                hAlign = _T("right");
+            }
+            DString vAlign = _T("top");
+            if (m_vAlignType == VerAlignType::kAlignCenter) {
+                vAlign = _T("center");
+            }
+            else if (m_vAlignType == VerAlignType::kAlignBottom) {
+                vAlign = _T("bottom");
+            }
+            rcControlDest = ImageAttribute::CalculateAdaptiveRect(nImageWidth, nImageHeight, rcControlDest, hAlign, vAlign);
+            imageSize.cx = rcControlDest.Width();
+            imageSize.cy = rcControlDest.Height();
+        }
+    }
+
+    //图片大小，需要附加控件的内边距
+    if (imageSize.cx > 0) {
+        imageSize.cx += (rcControlPadding.left + rcControlPadding.right);
+    }
+    if (imageSize.cy > 0) {
+        imageSize.cy += (rcControlPadding.top + rcControlPadding.bottom);
+    }
+    if ((estImageType == EstimateImageType::kBoth) || (estImageType == EstimateImageType::kWidthOnly)) {
+        //宽度为自动计算
+        estSize.cx = std::max(estSize.cx, imageSize.cx);
+    }
+    if ((estImageType == EstimateImageType::kBoth) || (estImageType == EstimateImageType::kHeightOnly)) {
+        //高度为自动计算
+        estSize.cy = std::max(estSize.cy, imageSize.cy);
+    }
+    return estSize;
+}
+
+void BitmapControl::ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale)
+{
+    BaseClass::ChangeDpiScale(nOldDpiScale, nNewDpiScale);
+    if (!Dpi().CheckDisplayScaleFactor(nNewDpiScale)) {
+        return;
+    }
+    if (HasBitmapDest()) {
+        UiRect rcDest = GetBitmapDest();
+        rcDest = Dpi().GetScaleRect(rcDest, nOldDpiScale);
+        SetBitmapDest(rcDest, false);
+    }
+    if (HasBitmapSource()) {
+        UiRect rcSource = GetBitmapSource();
+        rcSource = Dpi().GetScaleRect(rcSource, nOldDpiScale);
+        SetBitmapSource(rcSource, false);
+    }
+    if (HasBitmapMargin()) {
+        UiMargin rcMargin = GetBitmapMargin();
+        rcMargin = Dpi().GetScaleMargin(rcMargin, nOldDpiScale);
+        SetBitmapMargin(rcMargin, false);
+    }
+}
+
+void BitmapControl::SetBitmapHAlignType(HorAlignType hAlignType)
+{
+    if (m_hAlignType != hAlignType) {
+        m_hAlignType = hAlignType;
+        //重绘图片
+        Invalidate();
+    }
+}
+
+HorAlignType BitmapControl::GetBitmapHAlignType() const
+{
+    return m_hAlignType;
+}
+
+void BitmapControl::SetBitmapVAlignType(VerAlignType vAlignType)
+{
+    if (m_vAlignType != vAlignType) {
+        m_vAlignType = vAlignType;
+        //重绘图片
+        Invalidate();
+    }
+}
+
+VerAlignType BitmapControl::GetBitmapVAlignType() const
+{
+    return m_vAlignType;
+}
+
+void BitmapControl::SetBitmapAlpha(uint8_t nBitmapAlpha)
+{
+    ASSERT((nBitmapAlpha >= 0) && (nBitmapAlpha <= 255));
+    if ((nBitmapAlpha < 0) || (nBitmapAlpha > 255)) {
+        return;
+    }
+    if (m_nBitmapAlpha != nBitmapAlpha) {
+        m_nBitmapAlpha = nBitmapAlpha;
+        //重绘图片
+        Invalidate();
+    }
+}
+
+uint8_t BitmapControl::GetBitmapAlpha() const
+{
+    return m_nBitmapAlpha;
+}
+
+void BitmapControl::SetBitmapDest(UiRect rcDest, bool bNeedDpiScale)
+{
+    if (bNeedDpiScale) {
+        Dpi().ScaleRect(rcDest);
+    }
+    rcDest.Validate();
+    if (m_rcDest == nullptr) {
+        m_rcDest = std::make_unique<UiRect>(rcDest);
+        //重绘图片
+        Invalidate();
+    }
+    else {
+        if (*m_rcDest != rcDest) {
+            *m_rcDest = rcDest;
+            //重绘图片
+            Invalidate();
+        }
+    }
+}
+
+UiRect BitmapControl::GetBitmapDest() const
+{
+    if (m_rcDest != nullptr) {
+        return *m_rcDest;
+    }
+    return UiRect();
+}
+
+bool BitmapControl::HasBitmapDest() const
+{
+    return (m_rcDest != nullptr);
+}
+
+void BitmapControl::SetBitmapSource(UiRect rcSource, bool bNeedDpiScale)
+{
+    if (bNeedDpiScale) {
+        Dpi().ScaleRect(rcSource);
+    }
+    rcSource.Validate();
+    if (m_rcSource == nullptr) {
+        m_rcSource = std::make_unique<UiRect>(rcSource);
+        //重绘图片
+        Invalidate();
+    }
+    else {
+        if (*m_rcSource != rcSource) {
+            *m_rcSource = rcSource;
+            //重绘图片
+            Invalidate();
+        }
+    }
+}
+
+UiRect BitmapControl::GetBitmapSource() const
+{
+    if (m_rcSource != nullptr) {
+        return *m_rcSource;
+    }
+    return UiRect();
+}
+
+bool BitmapControl::HasBitmapSource() const
+{
+    return (m_rcSource != nullptr);
+}
+
+void BitmapControl::SetBitmapMargin(UiMargin rcMargin, bool bNeedDpiScale)
+{
+    if (bNeedDpiScale) {
+        Dpi().ScaleMargin(rcMargin);
+    }
+    if (m_rcMargin == nullptr) {
+        m_rcMargin = std::make_unique<UiMargin>(rcMargin);
+        //重绘图片
+        Invalidate();
+    }
+    else {
+        if (*m_rcMargin != rcMargin) {
+            *m_rcMargin = rcMargin;
+            //重绘图片
+            Invalidate();
+        }
+    }
+}
+
+UiMargin BitmapControl::GetBitmapMargin() const
+{
+    if (m_rcMargin != nullptr) {
+        return *m_rcMargin;
+    }
+    return UiMargin();
+}
+
+bool BitmapControl::HasBitmapMargin() const
+{
+    return (m_rcMargin != nullptr);
+}
+
+void BitmapControl::SetAdaptiveDestRect(bool bAdaptiveDestRect)
+{
+    if (m_bAdaptiveDestRect != bAdaptiveDestRect) {
+        m_bAdaptiveDestRect = bAdaptiveDestRect;
+        //重绘图片
+        Invalidate();
+    }
+}
+
+bool BitmapControl::IsAdaptiveDestRect() const
+{
+    return m_bAdaptiveDestRect;
+}
+
+void BitmapControl::SetStretchedDrawing(bool bStretchedDrawing)
+{
+    if (m_bStretchedDrawing != bStretchedDrawing) {
+        m_bStretchedDrawing = bStretchedDrawing;
+        //重绘图片
+        Invalidate();
+    }
+}
+
+bool BitmapControl::IsStretchedDrawing() const
+{
+    return m_bStretchedDrawing;
+}
+
+void BitmapControl::SetSupportMultiThread(bool bSupportMultiThread)
+{
+    m_bSupportMultiThread = bSupportMultiThread;
+}
+
+bool BitmapControl::IsSupportMultiThread() const
+{
+    return m_bSupportMultiThread;
+}
+
+void BitmapControl::Paint(IRender* pRender, const UiRect& rcPaint)
+{
+    BaseClass::Paint(pRender, rcPaint);
+
+    //绘制图片
+    PaintBitmap(pRender, rcPaint);
+}
+
+void BitmapControl::CheckLoadBitmapFile()
+{
+    if (!m_bitmapFile.empty() && (m_pBitmap == nullptr)) {
+        //加载指定的图片: 加载图片数据时无优化，仅供测试功能时使用
+        ImageDecodeParam decodeParam;
+        FilePath resPath = ui::GlobalManager::Instance().GetResourcePath();
+        resPath += m_bitmapFile.c_str();
+        decodeParam.m_imageFilePath = resPath;
+        decodeParam.m_pFileData = std::make_shared<std::vector<uint8_t>>();
+        decodeParam.m_fImageSizeScale = Dpi().GetDisplayScale();
+        FileUtil::ReadFileData(decodeParam.m_imageFilePath, *decodeParam.m_pFileData);
+        std::shared_ptr<IBitmap> pBitmap = GlobalManager::Instance().ImageDecoders().DecodeImageData(decodeParam);
+        ASSERT(pBitmap != nullptr);
+        if (pBitmap != nullptr) {
+            SetBitmapDataWithCopy(pBitmap.get());
+        }
+    }
+}
+
+bool BitmapControl::SetBitmapData(int32_t nWidth, int32_t nHeight, const uint8_t* pPixelBits, int32_t nPixelBitsSize)
+{
+    ASSERT((pPixelBits != nullptr) && (nPixelBitsSize > 0) && (nWidth > 0) && (nHeight > 0));
+    if ((pPixelBits == nullptr) || (nPixelBitsSize <= 0) || (nWidth <= 0) || (nHeight <= 0)) {
+        return false;
+    }
+    ASSERT(nPixelBitsSize == nHeight * nWidth * (int32_t)sizeof(uint32_t));
+    if (nPixelBitsSize != nHeight * nWidth * (int32_t)sizeof(uint32_t)) {
+        return false;
+    }
+
+    //支持多线程时，对m_pBitmap操作前先加锁
+    std::unique_ptr<std::unique_lock<std::mutex>> spMutexLock;
+    if (IsSupportMultiThread()) {
+        spMutexLock = std::make_unique<std::unique_lock<std::mutex>>(m_bitmapMutex);
+    }
+
+    if (m_pBitmap == nullptr) {
+        IRenderFactory* pRenderFactory = GlobalManager::Instance().GetRenderFactory();
+        ASSERT(pRenderFactory != nullptr);
+        if (pRenderFactory != nullptr) {
+            m_pBitmap.reset(pRenderFactory->CreateBitmap());
+        }
+    }
+    ASSERT(m_pBitmap != nullptr);
+    if (m_pBitmap == nullptr) {
+        return false;
+    }
+    bool bRet = false;
+    if (((int32_t)m_pBitmap->GetWidth() == nWidth) && ((int32_t)m_pBitmap->GetHeight() == nHeight)) {
+        void* pBits = m_pBitmap->LockPixelBits();
+        if (pBits != nullptr) {
+            //复制图片数据到位图
+            ::memcpy(pBits, pPixelBits, nWidth * nHeight * sizeof(uint32_t));
+            m_pBitmap->UnLockPixelBits();
+            bRet = true;
+        }
+    }
+    else {
+        bRet = m_pBitmap->Init(nWidth, nHeight, pPixelBits);
+    }
+    if (bRet) {
+        //重绘图片
+        Invalidate();
+    }
+    return bRet;
+}
+
+bool BitmapControl::SetBitmapDataWithCopy(IBitmap* pBitmap)
+{
+    if (pBitmap == nullptr) {
+        return false;
+    }
+    int32_t nWidth = pBitmap->GetWidth();
+    int32_t nHeight = pBitmap->GetHeight();
+    const uint8_t* pPixelBits = (const uint8_t*)pBitmap->LockPixelBits();
+    int32_t nPixelBitsSize = nHeight * nWidth * sizeof(uint32_t);
+    return SetBitmapData(nWidth, nHeight, pPixelBits, nPixelBitsSize);
+}
+
+void BitmapControl::ClearBitmapData()
+{
+    //支持多线程时，对m_pBitmap操作前先加锁
+    std::unique_ptr<std::unique_lock<std::mutex>> spMutexLock;
+    if (IsSupportMultiThread()) {
+        spMutexLock = std::make_unique<std::unique_lock<std::mutex>>(m_bitmapMutex);
+    }
+    if (m_pBitmap != nullptr) {
+        m_pBitmap.reset();
+        //重绘图片
+        Invalidate();
+    }    
+}
+
+bool BitmapControl::HasBitmapData()
+{
+    //支持多线程时，对m_pBitmap操作前先加锁
+    std::unique_ptr<std::unique_lock<std::mutex>> spMutexLock;
+    if (IsSupportMultiThread()) {
+        spMutexLock = std::make_unique<std::unique_lock<std::mutex>>(m_bitmapMutex);
+    }
+    return (m_pBitmap != nullptr) && (m_pBitmap->GetWidth() > 0) && (m_pBitmap->GetHeight() > 0);
+}
+
+void BitmapControl::GetBitmapSize(int32_t& nImageWidth, int32_t& nImageHeight)
+{
+    //支持多线程时，对m_pBitmap操作前先加锁
+    std::unique_ptr<std::unique_lock<std::mutex>> spMutexLock;
+    if (IsSupportMultiThread()) {
+        spMutexLock = std::make_unique<std::unique_lock<std::mutex>>(m_bitmapMutex);
+    }
+    nImageWidth = 0;
+    nImageHeight = 0;
+    IBitmap* pBitmap = m_pBitmap.get();
+    if (pBitmap != nullptr) {
+        nImageWidth = pBitmap->GetWidth();
+        nImageHeight = pBitmap->GetHeight();
+    }
+}
+
+void BitmapControl::PaintBitmap(IRender* pRender, const UiRect& rcPaint)
+{
+    GlobalManager::Instance().AssertUIThread();
+
+    //按需加载指定的图片
+    CheckLoadBitmapFile();
+
+    //统计绘制图片的性能
+    PerformanceStat statPerformance(_T("BitmapControl::Paint"));
+
+    //支持多线程时，对m_pBitmap操作前先加锁
+    std::unique_ptr<std::unique_lock<std::mutex>> spMutexLock;
+    if (IsSupportMultiThread()) {
+        spMutexLock = std::make_unique<std::unique_lock<std::mutex>>(m_bitmapMutex);
+    }
+
+    int32_t nImageInfoWidth = 0;
+    int32_t nImageInfoHeight = 0;
+    IBitmap* pBitmap = m_pBitmap.get();
+    if (pBitmap != nullptr) {
+        nImageInfoWidth = pBitmap->GetWidth();
+        nImageInfoHeight = pBitmap->GetHeight();
+    }
+    if ((nImageInfoWidth <= 0) || (nImageInfoHeight <= 0)) {
+        //没有图像数据
+        return;
+    }
+
+    UiRect rcDest;
+    if (m_rcDest != nullptr) {
+        //使用配置中指定的目标区域
+        rcDest = *m_rcDest;
+        if (rcDest.left < 0) {
+            rcDest.left = 0;
+        }
+        if (rcDest.top < 0) {
+            rcDest.top = 0;
+        }
+        if (rcDest.right <= rcDest.left) {
+            rcDest.right = rcDest.left + nImageInfoWidth;
+        }
+        if (rcDest.bottom <= rcDest.top) {
+            rcDest.bottom = rcDest.top + nImageInfoHeight;
+        }
+        rcDest.Offset(GetRect().left, GetRect().top);
+    }
+    else {
+        rcDest = GetRect();
+        rcDest.Deflate(GetControlPadding());
+    }
+
+    //图片的外边距(剪去)
+    if (m_rcMargin != nullptr) {
+        rcDest.Deflate(*m_rcMargin);
+    }
+
+    UiRect rcTemp;
+    if (!UiRect::Intersect(rcTemp, rcDest, GetRect())) {
+        return;//rcDest与目标区域无交集，无法绘制
+    }
+
+    UiRect rcSource;
+    if (m_rcSource != nullptr) {
+        rcSource = *m_rcSource;        
+        if (rcSource.right > (int32_t)m_pBitmap->GetWidth()) {
+            rcSource.right = (int32_t)m_pBitmap->GetWidth();
+        }
+        if (rcSource.bottom > (int32_t)m_pBitmap->GetHeight()) {
+            rcSource.bottom = (int32_t)m_pBitmap->GetHeight();
+        }
+    }
+    else {
+        rcSource.left = 0;
+        rcSource.top = 0;
+        rcSource.right = rcSource.left + m_pBitmap->GetWidth();
+        rcSource.bottom = rcSource.top + m_pBitmap->GetHeight();
+    }
+
+    rcSource.Validate();
+    if (rcSource.IsEmpty()) {
+        return;//无有效数据区域
+    }
+
+    const int32_t nImageWidth = rcSource.Width();
+    const int32_t nImageHeight = rcSource.Height();
+
+    bool bAdaptiveDestRect = m_bAdaptiveDestRect; //自动适应目标区域（等比例缩放后，按指定对齐方式绘制）
+    bool bStretchedDrawing = m_bStretchedDrawing; //拉伸绘制，其优先级低于bAdaptiveDestRect这个选项
+    if (!bAdaptiveDestRect && !bStretchedDrawing) {
+        //当图片的大小，大于目标区域大小时，固定设置为自动适应目标区域
+        if ((nImageWidth > rcDest.Width()) || (nImageHeight > rcDest.Height())) {
+            bAdaptiveDestRect = true;
+        }
+    }
+    if (bAdaptiveDestRect) {
+        //自动适应目标区域（等比例缩放图片）：根据图片大小，调整绘制区域
+        DString hAlign = _T("left");
+        if (m_hAlignType == HorAlignType::kAlignCenter) {
+            hAlign = _T("center");
+        }
+        else if (m_hAlignType == HorAlignType::kAlignRight) {
+            hAlign = _T("right");
+        }
+        DString vAlign = _T("top");
+        if (m_vAlignType == VerAlignType::kAlignCenter) {
+            vAlign = _T("center");
+        }
+        else if (m_vAlignType == VerAlignType::kAlignBottom) {
+            vAlign = _T("bottom");
+        }
+        rcDest = ImageAttribute::CalculateAdaptiveRect(nImageWidth, nImageHeight, rcDest, hAlign, vAlign);
+    }
+    else if (!bStretchedDrawing) {
+        //不是拉伸绘制，处理对齐方式
+        if (m_hAlignType == HorAlignType::kAlignLeft) {
+            rcDest.right = rcDest.left + nImageWidth;
+        }
+        else if (m_hAlignType == HorAlignType::kAlignCenter) {
+            rcDest.left = rcDest.CenterX() - nImageWidth / 2;
+            rcDest.right = rcDest.left + nImageWidth;
+        }
+        else if (m_hAlignType == HorAlignType::kAlignRight) {
+            rcDest.left = rcDest.right - nImageWidth;
+        }
+
+        if (m_vAlignType == VerAlignType::kAlignTop) {
+            rcDest.bottom = rcDest.top + nImageHeight;
+        }
+        else if (m_vAlignType == VerAlignType::kAlignCenter) {
+            rcDest.top = rcDest.CenterY() - nImageHeight / 2;
+            rcDest.bottom = rcDest.top + nImageHeight;
+        }
+        else if (m_vAlignType == VerAlignType::kAlignBottom) {
+            rcDest.top = rcDest.bottom - nImageHeight;
+        }
+    }
+    pRender->DrawImage(rcPaint, m_pBitmap.get(), rcDest, rcSource, m_nBitmapAlpha);
+}
+
+}//namespace ui

--- a/duilib/Control/BitmapControl.h
+++ b/duilib/Control/BitmapControl.h
@@ -1,0 +1,224 @@
+#ifndef UI_CONTROL_BITMAP_CONTROL_H_
+#define UI_CONTROL_BITMAP_CONTROL_H_
+
+#include "duilib/Core/Box.h"
+#include <mutex>
+
+namespace ui
+{
+class IBitmap;
+
+/** 用于显示位图数据的控件，适合显示基于内存的位图数据，并且支持图片资源的各种属性
+ *  位图的数据格式为32位的位图(外部处理)：
+ *    Windows平台为BGRA: struct BGRA { uint8_t b, g, r, a; };
+ *    非Windows平台RGBA: struct RGBA { uint8_t r, g, b, a; };
+ *  位图的alpha type为kPremul_SkAlphaType(外部预乘)
+ *  线程模型：
+ *     （1）对于位图数据操作相关的函数：支持多线程，可以在子线程中操作位图数据，位图的绘制是在UI线程中进行的
+ *     （2）对于非位图数据操作相关的函数：只能在UI线程中调用，不支持多线程
+ */
+class BitmapControl : public Box
+{
+    typedef Box BaseClass;
+public:
+    explicit BitmapControl(Window* pWindow);
+    virtual ~BitmapControl() override;
+    BitmapControl(const BitmapControl&) = delete;
+    BitmapControl& operator=(const BitmapControl&) = delete;
+
+    /** 获取控件类型
+    */
+    virtual DString GetType() const override;
+    virtual void SetAttribute(const DString& strName, const DString& strValue) override;
+
+    /** 计算图片区域大小（宽和高）
+     *  @param [in] szAvailable 可用大小，不包含内边距，不包含外边距
+     *  @param [in] estImageType 估算图片的类型
+     *  @return 控件的图片估算大小，包含内边距(Box)，不包含外边距
+     */
+    virtual UiSize EstimateImage(UiSize szAvailable, EstimateImageType estImageType) override;
+
+    /** DPI发生变化，更新控件大小和布局
+    * @param [in] nOldDpiScale 旧的DPI缩放百分比
+    * @param [in] nNewDpiScale 新的DPI缩放百分比，与Dpi().GetScale()的值一致
+    */
+    virtual void ChangeDpiScale(uint32_t nOldDpiScale, uint32_t nNewDpiScale) override;
+
+public:
+    /** 设置位图数据，数据会被复制一份保存
+     * @param [in] nWidth 宽度
+     * @param [in] nHeight 高度
+     * @param [in] pPixelBits 位图数据
+     * @param [in] nPixelBitsSize 位图数据的长度（按字节）
+     */
+    bool SetBitmapData(int32_t nWidth, int32_t nHeight, const uint8_t* pPixelBits, int32_t nPixelBitsSize);
+
+    /** 设置位图数据，数据会被复制一份保存
+     * @param [in] pBitmap 位图数据接口
+     */
+    bool SetBitmapDataWithCopy(IBitmap* pBitmap);
+
+    /** 清除位图数据
+    */
+    void ClearBitmapData();
+
+    /** 获取当前是否含有位图数据
+    */
+    bool HasBitmapData();
+
+public:
+    /** 设置位图图片绘制时水平对齐方式
+    */
+    void SetBitmapHAlignType(HorAlignType hAlignType);
+
+    /** 获取位图图片绘制时水平对齐方式
+    */
+    HorAlignType GetBitmapHAlignType() const;
+
+    /** 设置位图图片绘制时垂直对齐方式
+    */
+    void SetBitmapVAlignType(VerAlignType vAlignType);
+
+    /** 获取位图图片绘制时垂直对齐方式
+    */
+    VerAlignType GetBitmapVAlignType() const;
+
+    /** 设置绘制图片时的透明度（0 - 255）
+    */
+    void SetBitmapAlpha(uint8_t nBitmapAlpha);
+
+    /** 获取绘制图片时的透明度（0 - 255）
+    */
+    uint8_t GetBitmapAlpha() const;
+
+    /** 设置绘制目标区域位置和大小(相对于控件区域的位置)
+    * @param [in] rcDest 绘制目标区域位置和大小
+    * @param [in] bNeedDpiScale 是否需要DPI缩放
+    */
+    void SetBitmapDest(UiRect rcDest, bool bNeedDpiScale);
+
+    /** 获取绘制目标区域位置和大小(相对于控件区域的位置)
+    * @return 返回绘制目标区域位置和大小，已做过DPI缩放
+    */
+    UiRect GetBitmapDest() const;
+
+    /** 是否设置了绘制目标区域位置和大小(相对于控件区域的位置)
+    */
+    bool HasBitmapDest() const;
+
+    /** 设置绘制源区域位置和大小
+    * @param [in] rcSource 绘制源区域位置和大小
+    * @param [in] bNeedDpiScale 是否需要DPI缩放
+    */
+    void SetBitmapSource(UiRect rcSource, bool bNeedDpiScale);
+
+    /** 获取绘制源区域位置和大小
+    * @return 返回绘制目标区域位置和大小，已做过DPI缩放
+    */
+    UiRect GetBitmapSource() const;
+
+    /** 是否设置了绘制源区域位置和大小
+    */
+    bool HasBitmapSource() const;
+
+    /** 设置绘制目标区域中的外边距(如果指定了rcDest值，此值无效)
+    * @param [in] rcMargin 绘制源区域位置和大小
+    * @param [in] bNeedDpiScale 是否需要DPI缩放
+    */
+    void SetBitmapMargin(UiMargin rcMargin, bool bNeedDpiScale);
+
+    /** 获取绘制目标区域中的外边距(如果指定了rcDest值，此值无效)
+    * @return 返回绘制目标区域位置和大小，已做过DPI缩放
+    */
+    UiMargin GetBitmapMargin() const;
+
+    /** 是否设置了绘制目标区域中的外边距(如果指定了rcDest值，此值无效)
+    */
+    bool HasBitmapMargin() const;
+
+    /** 设置绘制时是否自动适应目标区域（等比例缩放图片）
+    * @param [in] bAdaptiveDestRect true表示绘制时自动适应目标区域（等比例缩放图片）
+    */
+    void SetAdaptiveDestRect(bool bAdaptiveDestRect);
+
+    /** 获取绘制时是否自动适应目标区域（等比例缩放图片）
+    */
+    bool IsAdaptiveDestRect() const;
+
+    /** 设置绘制时是否拉伸绘制图片（与IsAdaptiveDestRect()互斥，优先级低于IsAdaptiveDestRect()）
+    * @param [in] bStretchedDrawing true表示绘制时拉伸绘制图片，false表示绘制时不拉伸绘制图片
+    */
+    void SetStretchedDrawing(bool bStretchedDrawing);
+
+    /** 获取绘制时绘制时是否拉伸绘制图片
+    */
+    bool IsStretchedDrawing() const;
+
+    /** 设置是否支持多线程操作位图数据（如果无调用，则默认为true，默认是支持多线程操作位图数据的）
+    * @param [in] bSupportMultiThread true表示支持多线程操作位图数据，false表示不支持多线程操作位图数据
+    */
+    void SetSupportMultiThread(bool bSupportMultiThread);
+
+    /** 获取是否支持多线程操作位图数据
+    */
+    bool IsSupportMultiThread() const;
+
+protected:
+    /** 重写父控件绘制函数
+    */
+    virtual void Paint(IRender* pRender, const UiRect& rcPaint) override;
+
+private:
+    /** 获取位图图片的宽度和高度
+    */
+    void GetBitmapSize(int32_t& nImageWidth, int32_t& nImageHeight);
+
+    /** 绘制图片
+    */
+    void PaintBitmap(IRender* pRender, const UiRect& rcPaint);
+
+    /** 加载指定的图片
+    */
+    void CheckLoadBitmapFile();
+
+private:
+    // 位图数据锁，支持在子线程中操作位图数据
+    std::mutex m_bitmapMutex;
+
+    //用于绘制的位图数据
+    std::unique_ptr<IBitmap> m_pBitmap;
+
+    //关联的图片文件：主要用于测试
+    UiString m_bitmapFile;
+
+    //绘制目标区域位置和大小(相对于控件区域的位置)
+    std::unique_ptr<UiRect> m_rcDest;
+
+    //图片源区域位置和大小
+    std::unique_ptr<UiRect> m_rcSource;
+
+    //在绘制目标区域中的外边距(如果指定了rcDest值，此值无效)
+    std::unique_ptr<UiMargin> m_rcMargin;
+
+    //图片的水平对齐方式
+    HorAlignType m_hAlignType;
+
+    //图片的垂直对齐方式
+    VerAlignType m_vAlignType;
+
+    //透明度（0 - 255）
+    uint8_t m_nBitmapAlpha;
+
+    //是否自动适应目标区域（等比例缩放图片）
+    bool m_bAdaptiveDestRect;
+
+    //是否拉伸绘制图片
+    bool m_bStretchedDrawing;
+
+    //是否支持多线程操作位图数据
+    bool m_bSupportMultiThread;
+};
+
+}//namespace ui
+
+#endif //UI_CONTROL_BITMAP_CONTROL_H_

--- a/duilib/Control/IconControl.cpp
+++ b/duilib/Control/IconControl.cpp
@@ -19,6 +19,7 @@ DString IconControl::GetType() const { return DUI_CTR_ICON_CONTROL; }
 
 bool IconControl::SetIconData(int32_t nWidth, int32_t nHeight, const uint8_t* pPixelBits, int32_t nPixelBitsSize)
 {
+    GlobalManager::Instance().AssertUIThread();
     ASSERT((pPixelBits != nullptr) && (nPixelBitsSize > 0) && (nWidth > 0) && (nHeight > 0));
     if ((pPixelBits == nullptr) || (nPixelBitsSize <= 0) || (nWidth <= 0) || (nHeight <= 0)) {
         return false;
@@ -60,6 +61,7 @@ bool IconControl::SetIconData(int32_t nWidth, int32_t nHeight, const uint8_t* pP
 
 void IconControl::ClearIconData()
 {
+    GlobalManager::Instance().AssertUIThread();
     if (m_pBitmap != nullptr) {
         m_pBitmap.reset();
         //重绘图片
@@ -69,6 +71,7 @@ void IconControl::ClearIconData()
 
 bool IconControl::HasIconData() const
 {
+    GlobalManager::Instance().AssertUIThread();
     return (m_pBitmap != nullptr) && (m_pBitmap->GetWidth() > 0) && (m_pBitmap->GetHeight() > 0);
 }
 

--- a/duilib/Control/IconControl.h
+++ b/duilib/Control/IconControl.h
@@ -7,21 +7,28 @@ namespace ui
 {
 class IBitmap;
 
-/** 用于显示图标的控件，如果不设置图标数据，则兼容基类Control的所有功能
-*/
+/** 用于显示图标的控件，适合小图标类的图片资源显示，功能较简单
+ *  位图的数据格式为32位的位图(外部处理)：
+ *    Windows平台为BGRA: struct BGRA { uint8_t b, g, r, a; };
+ *    非Windows平台RGBA: struct RGBA { uint8_t r, g, b, a; };
+ *  位图的alpha type为kPremul_SkAlphaType(外部预乘)
+ *  线程模型：单线程，只能在UI线程中使用
+ */
 class IconControl : public Control
 {
     typedef Control BaseClass;
 public:
     explicit IconControl(Window* pWindow);
     virtual ~IconControl() override;
+    IconControl(const IconControl&) = delete;
+    IconControl& operator=(const IconControl&) = delete;
 
     /** 获取控件类型
     */
     virtual DString GetType() const override;
 
 public:
-    /** 设置图标的位图数据(数据格式：ARGB格式，alpha type为kPremul_SkAlphaType)
+    /** 设置图标的位图数据
     * @param [in] nWidth 宽度
     * @param [in] nHeight 高度
     * @param [in] pPixelBits 位图数据

--- a/duilib/Core/WindowBuilder.cpp
+++ b/duilib/Core/WindowBuilder.cpp
@@ -36,6 +36,7 @@
 #include "duilib/Control/PropertyGrid.h"
 #include "duilib/Control/TabCtrl.h"
 #include "duilib/Control/IconControl.h"
+#include "duilib/Control/BitmapControl.h"
 #include "duilib/Control/AddressBar.h"
 #include "duilib/Control/MenuBar.h"
 
@@ -152,6 +153,7 @@ Control* WindowBuilder::CreateControlByClass(const DString& strControlClass, Win
         {DUI_CTR_TAB_CTRL, [](Window* pWindow) { return new TabCtrl(pWindow); }},
         {DUI_CTR_TAB_CTRL_ITEM, [](Window* pWindow) { return new TabCtrlItem(pWindow); }},
         {DUI_CTR_ICON_CONTROL, [](Window* pWindow) { return new IconControl(pWindow); }},
+        {DUI_CTR_BITMAP_CONTROL, [](Window* pWindow) { return new BitmapControl(pWindow); }},
         {DUI_CTR_ADDRESS_BAR, [](Window* pWindow) { return new AddressBar(pWindow); }},
         {DUI_CTR_MENU_BAR, [](Window* pWindow) { return new MenuBar(pWindow); }},
 

--- a/duilib/Image/ImageInfo.cpp
+++ b/duilib/Image/ImageInfo.cpp
@@ -31,7 +31,8 @@ ImageInfo::~ImageInfo()
 void ImageInfo::ReleaseImage()
 {
     if (m_pImageData != nullptr) {
-        GlobalManager::Instance().Image().ReleaseImage(m_pImageData);
+        DString imageFullPath = m_loadParam.GetImageLoadPath().m_imageFullPath.ToString();
+        GlobalManager::Instance().Image().ReleaseImage(m_pImageData, imageFullPath);
         m_pImageData.reset();
     }
 }

--- a/duilib/duilib.h
+++ b/duilib/duilib.h
@@ -91,6 +91,7 @@
 #include "Control/PropertyGrid.h"
 #include "Control/TabCtrl.h"
 #include "Control/IconControl.h"
+#include "Control/BitmapControl.h"
 #include "Control/AddressBar.h"
 
 #include "Control/ListCtrl.h"

--- a/duilib/duilib.vcxproj
+++ b/duilib/duilib.vcxproj
@@ -251,6 +251,7 @@
     <ClCompile Include="CEFControl\internal\Windows\osr_ime_handler_win.cc" />
     <ClCompile Include="CEFControl\internal\Windows\util_win.cc" />
     <ClCompile Include="Control\AddressBar.cpp" />
+    <ClCompile Include="Control\BitmapControl.cpp" />
     <ClCompile Include="Control\CheckCombo.cpp" />
     <ClCompile Include="Control\CircleProgress.cpp" />
     <ClCompile Include="Control\ColorControl.cpp" />
@@ -587,6 +588,7 @@
     <ClInclude Include="CEFControl\internal\Windows\osr_ime_handler_win.h" />
     <ClInclude Include="CEFControl\internal\Windows\util_win.h" />
     <ClInclude Include="Control\AddressBar.h" />
+    <ClInclude Include="Control\BitmapControl.h" />
     <ClInclude Include="Control\CheckCombo.h" />
     <ClInclude Include="Control\ColorControl.h" />
     <ClInclude Include="Control\ColorConvert.h" />

--- a/duilib/duilib.vcxproj.filters
+++ b/duilib/duilib.vcxproj.filters
@@ -852,6 +852,9 @@
     <ClCompile Include="Core\FullscreenBox.cpp">
       <Filter>Core</Filter>
     </ClCompile>
+    <ClCompile Include="Control\BitmapControl.cpp">
+      <Filter>Control</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Animation\AnimationManager.h">
@@ -1762,6 +1765,9 @@
     </ClInclude>
     <ClInclude Include="Core\FullscreenBox.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="Control\BitmapControl.h">
+      <Filter>Control</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/duilib/duilib_defs.h
+++ b/duilib/duilib_defs.h
@@ -120,9 +120,10 @@ namespace ui
     #define  DUI_CTR_IPADDRESS                       (_T("IPAddress"))
     #define  DUI_CTR_HOTKEY                          (_T("HotKey"))
     #define  DUI_CTR_TAB_CTRL                        (_T("TabCtrl"))
-    #define  DUI_CTR_TAB_CTRL_ITEM                   (_T("TabCtrlItem"))
-    #define  DUI_CTR_ICON_CONTROL                    (_T("IconControl"))
+    #define  DUI_CTR_TAB_CTRL_ITEM                   (_T("TabCtrlItem"))    
     #define  DUI_CTR_ADDRESS_BAR                     (_T("AddressBar"))
+    #define  DUI_CTR_ICON_CONTROL                    (_T("IconControl"))
+    #define  DUI_CTR_BITMAP_CONTROL                  (_T("BitmapControl"))
 
     // 窗口标题栏按钮：最大化、最小化、关闭、还原、全屏窗口的名字，代码中写死的
     #define  DUI_CTR_CAPTION_BAR                     (_T("window_caption_bar"))


### PR DESCRIPTION
新增控件：BitmapControl，用来显示基于内存的图像数据。
增加新函数：void ImageManager::SetReleaseImageCallback(ReleaseImageCallback callback)，在将图片资源放入缓存队列时，先调用回调函数，提供阻止图片资源进入缓存队列的机会，确保可以立即释放图片资源。

