### PR TITLE
补充ListBoxItem的属性描述文档（#337）/ 窗口事件相关的结构调整：窗口的事件与控件的事件分开管理，避免混淆；窗口的事件统一放在WindowBase里面管理。

### DIFF
--- a/docs/Control.md
+++ b/docs/Control.md
@@ -563,6 +563,16 @@ TabCtrlItem 控件继承了 `ControlDragableT` 属性，更多可用属性请参
 | drag_out    | true| bool | 是否支持拖出操作（在相同窗口的不同容器内），默认是开启的 |
 | drag_alpha  | 216 | uint8_t | 拖动顺序时，控件的透明度 |
 
+## ListBoxItem的属性
+ListBoxItem是模板ListBoxItemTemplate类的一个具体实现，在`duilib/Box/ListBoxItem.h`文件中定义，相关的类型定义有三个：    
+```
+typedef ListBoxItemTemplate<Box> ListBoxItem;
+typedef ListBoxItemTemplate<HBox> ListBoxItemH;
+typedef ListBoxItemTemplate<VBox> ListBoxItemV;
+```
+ListBoxItem作为ListBox容器中的子项，其本身没有定义任何属性。
+ListBoxItem 继承了 `Option` 的属性，更多可用属性请参考`Option`的属性
+
 ## TreeView的属性
 | 属性名称 | 默认值 | 参数类型 | 用途 |
 | :--- | :--- | :--- | :--- |

--- a/docs/XmlEvents.md
+++ b/docs/XmlEvents.md
@@ -148,7 +148,6 @@ if (msg.eventType == eventType) {
 |kEventWindowMove|"WindowMove"|"window_move"|
 |kEventWindowCreate|"WindowCreate"|"window_create"|
 |kEventWindowClose|"WindowClose"|"window_close"|
-|kEventWindowFirstShown|"WindowFirstShown"|"window_first_shown"|
 |kEventClick|"Click"|"click"|
 |kEventRClick|"RClick"|"rclick"|
 |kEventMouseClickChanged|"MouseClickChanged"|"mouse_click_changed"|

--- a/duilib/Control/CheckCombo.cpp
+++ b/duilib/Control/CheckCombo.cpp
@@ -461,13 +461,21 @@ void CheckCombo::Activate(const EventArgs* /*pMsg*/)
     }
 
     m_pCheckComboWnd = new CCheckComboWnd();
-    m_pCheckComboWnd->AttachWindowCreate(ToWeakCallback([this](const ui::EventArgs& msg) {
-        FireAllEvents(msg);
+    m_pCheckComboWnd->AttachWindowCreateMsg(ToWeakCallback([this](const ui::EventArgs& /*args*/) {
+        //触发消息到应用层(下拉窗口创建)
+        EventArgs msg;
+        msg.SetSender(this);
+        msg.eventType = kEventWindowCreate;
+        FireNormalEvents(msg);
         return true;
         }));
     m_pCheckComboWnd->InitComboWnd(this);
-    m_pCheckComboWnd->AttachWindowClose(ToWeakCallback([this](const ui::EventArgs& msg) {
-        FireAllEvents(msg);
+    m_pCheckComboWnd->AttachWindowCloseMsg(ToWeakCallback([this](const ui::EventArgs& /*args*/) {
+        //触发消息到应用层(下拉窗口销毁)
+        EventArgs msg;
+        msg.SetSender(this);
+        msg.eventType = kEventWindowClose;
+        FireNormalEvents(msg);
         return true;
     }));
     Invalidate();

--- a/duilib/Control/ColorPicker.cpp
+++ b/duilib/Control/ColorPicker.cpp
@@ -101,7 +101,7 @@ void ColorPicker::AttachSelectColor(const EventCallback& callback)
 
 void ColorPicker::AttachWindowClose(const EventCallback& callback)
 {
-    BaseClass::AttachWindowClose(callback);
+    BaseClass::AttachWindowCloseMsg(callback);
 }
 
 Control* ColorPicker::CreateControl(const DString& strClass)
@@ -788,7 +788,7 @@ void ColorPicker::OnPickColorFromScreen()
     pScreenColorPicker->CreateWnd(nullptr, createWndParam);
     pScreenColorPicker->ShowWindow(ui::kSW_SHOW_NORMAL);
     pScreenColorPicker->EnterFullscreen();
-    pScreenColorPicker->AttachWindowClose([this, pScreenColorPicker, bHideWindow](const ui::EventArgs& /*args*/) {
+    pScreenColorPicker->AttachWindowCloseMsg([this, pScreenColorPicker, bHideWindow](const ui::EventArgs& /*args*/) {
         //更新选择的颜色值
         UiColor selectedColor = pScreenColorPicker->GetSelColor();
         if (!selectedColor.IsEmpty()) {

--- a/duilib/Control/MenuBar.cpp
+++ b/duilib/Control/MenuBar.cpp
@@ -404,7 +404,7 @@ void MenuBar::ShowPopupMenu(MenuBarButton* pButton)
     pMenu->AttachMenuItemActivated(callback);
 
     //菜单关闭时，复位激活状态
-    pMenu->AttachWindowClose([this, pMenu, menuBarFlag](const EventArgs& /*args*/) {
+    pMenu->AttachWindowCloseMsg([this, pMenu, menuBarFlag](const EventArgs& /*args*/) {
             if (!menuBarFlag.expired() && (m_pActiveMenu == pMenu)) {
                 m_bActiveState = false;
             }

--- a/duilib/Control/RichEdit_SDL.cpp
+++ b/duilib/Control/RichEdit_SDL.cpp
@@ -2556,7 +2556,7 @@ void RichEdit::ShowPopupMenu(const ui::UiPoint& point)
 
     //菜单关闭事件
     std::weak_ptr<WeakFlag> richEditFlag = GetWeakFlag();
-    menu->AttachWindowClose([this, richEditFlag, bOldHideSelection](const ui::EventArgs&) {
+    menu->AttachWindowCloseMsg([this, richEditFlag, bOldHideSelection](const ui::EventArgs&) {
         if (!richEditFlag.expired()) {
             //恢复HideSelection属性
             SetHideSelection(bOldHideSelection);

--- a/duilib/Control/RichEdit_Windows.cpp
+++ b/duilib/Control/RichEdit_Windows.cpp
@@ -3110,7 +3110,7 @@ void RichEdit::ShowPopupMenu(const ui::UiPoint& point)
     }
     //菜单关闭事件
     std::weak_ptr<WeakFlag> richEditFlag = GetWeakFlag();
-    menu->AttachWindowClose([this, richEditFlag](const ui::EventArgs&) {
+    menu->AttachWindowCloseMsg([this, richEditFlag](const ui::EventArgs&) {
         if (!richEditFlag.expired()) {
             m_bContextMenuShown = false;
             //恢复HideSelection属性

--- a/duilib/Core/EventArgs.cpp
+++ b/duilib/Core/EventArgs.cpp
@@ -42,12 +42,14 @@ Control* EventArgs::GetSender() const
     }
 }
 
+void EventArgs::SetSenderWeakFlag(std::weak_ptr<WeakFlag> senderFlag)
+{
+    m_senderFlag = senderFlag;
+}
+
 bool EventArgs::IsSenderExpired() const
 {
-    if (pSender != nullptr) {
-        return m_senderFlag.expired();
-    }
-    return false;
+    return m_senderFlag.expired();
 }
 
 //EventType 与 String 相互转换的数据结构
@@ -102,7 +104,6 @@ static void InitEventStringMap(std::unordered_map<EventType, DString>* typeMap,
         {kEventWindowMove, _T("kEventWindowMove"), _T("WindowMove"), _T("window_move")},
         {kEventWindowCreate, _T("kEventWindowCreate"), _T("WindowCreate"), _T("window_create")},
         {kEventWindowClose, _T("kEventWindowClose"), _T("WindowClose"), _T("window_close")},
-        {kEventWindowFirstShown, _T("kEventWindowFirstShown"), _T("WindowFirstShown"), _T("window_first_shown")},
         {kEventClick, _T("kEventClick"), _T("Click"), _T("click")},
         {kEventRClick, _T("kEventRClick"), _T("RClick"), _T("rclick")},
         {kEventMouseClickChanged, _T("kEventMouseClickChanged"), _T("MouseClickChanged"), _T("mouse_click_changed")},

--- a/duilib/Core/EventArgs.h
+++ b/duilib/Core/EventArgs.h
@@ -6,7 +6,7 @@
 #include <functional>
 #include <vector>
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <memory>
 
 namespace ui
@@ -14,7 +14,7 @@ namespace ui
 class Control;
 class WeakFlag;
 
-/** 事件通知的参数
+/** 控件的事件通知的参数
 */
 struct UILIB_API EventArgs
 {
@@ -67,6 +67,10 @@ public:
     /** 获取发送事件的控件
     */
     Control* GetSender() const;
+
+    /** 设置发送事件的的WeakFlag（在不设置Sender时使用）
+    */
+    void SetSenderWeakFlag(std::weak_ptr<WeakFlag> senderFlag);
 
     /** 判断发送事件的控件是否失效
     */
@@ -141,7 +145,7 @@ private:
 
 /** 事件类型回调的map容器
 */
-typedef std::map<EventType, EventSource> EventMap;
+typedef std::unordered_map<EventType, EventSource> EventMap;
 
 /** 辅助函数
 */

--- a/duilib/Core/WindowBase.cpp
+++ b/duilib/Core/WindowBase.cpp
@@ -9,7 +9,8 @@ namespace ui
 {
 WindowBase::WindowBase():
     m_pParentWindow(nullptr), 
-    m_pNativeWindow(nullptr)
+    m_pNativeWindow(nullptr),
+    m_bWindowFirstShown(false)
 {
     m_pNativeWindow = new NativeWindow(this);
 }
@@ -52,6 +53,8 @@ int32_t WindowBase::DoModal(WindowBase* pParentWindow, const WindowCreateParam& 
 
 void WindowBase::OnNativeCreateWndMsg(bool bDoModal, const NativeMsg& nativeMsg, bool& bHandled)
 {
+    std::weak_ptr<WeakFlag> windowFlag = GetWeakFlag();
+
     //窗口完成创建，初始化（内部使用）
     InitWindowBase();
 
@@ -62,8 +65,15 @@ void WindowBase::OnNativeCreateWndMsg(bool bDoModal, const NativeMsg& nativeMsg,
     PostInitWindow();
 
     //调用子类的初始化函数
-    OnInitWindow();    
-    OnCreateWndMsg(bDoModal, nativeMsg, bHandled);
+    OnInitWindow();
+
+    if (!windowFlag.expired()) {
+        OnCreateWndMsg(bDoModal, nativeMsg, bHandled);
+    }    
+    if (!windowFlag.expired()) {
+        //给应用层回调
+        SendWindowEvent(kWindowCreateMsg, (WPARAM)bDoModal ? 1 : 0);
+    }
 }
 
 void WindowBase::ClearWindowBase()
@@ -194,6 +204,12 @@ WindowBase* WindowBase::GetParentWindow() const
 bool WindowBase::IsWindow() const
 {
     return m_pNativeWindow->IsWindow();
+}
+
+bool WindowBase::IsChildWindow() const
+{
+    return false;
+    //return m_pNativeWindow->IsChildWindow();
 }
 
 void WindowBase::InitWindowBase()
@@ -955,6 +971,15 @@ void WindowBase::OnNativeDisplayScaleChangedMsg(float fNewDisplayScale, float fN
 
 void WindowBase::OnNativeFinalMessage()
 {
+    if (IsChildWindow() || GlobalManager::Instance().Windows().HasWindowBase(this)) {
+        //发送一个窗口关闭事件
+        std::weak_ptr<WeakFlag> windowFlag = GetWeakFlag();
+        WPARAM wParam = (WPARAM)GetCloseParam();
+        SendWindowEvent(kWindowCloseMsg, wParam);
+        if (windowFlag.expired()) {
+            return;
+        }
+    }
     FinalMessage();
 }
 
@@ -982,28 +1007,46 @@ LRESULT WindowBase::OnNativeWindowMessage(UINT uMsg, WPARAM wParam, LPARAM lPara
 
 LRESULT WindowBase::OnNativeWindowPosChangedMsg(const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnWindowPosChangedMsg(nativeMsg, bHandled);
+    LRESULT lResult = OnWindowPosChangedMsg(nativeMsg, bHandled);
+    SendWindowEvent(kWindowPosChangedMsg);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeSizeMsg(WindowSizeType sizeType, const UiSize& newWindowSize, const NativeMsg& nativeMsg, bool& bHandled)
 {
     OnWindowSize(sizeType);
-    return OnSizeMsg(sizeType, newWindowSize, nativeMsg, bHandled);
+    LRESULT lResult = OnSizeMsg(sizeType, newWindowSize, nativeMsg, bHandled);
+    SendWindowEvent(kWindowSizeMsg, (WPARAM)sizeType);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMoveMsg(const UiPoint& ptTopLeft, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMoveMsg(ptTopLeft, nativeMsg, bHandled);
+    LRESULT lResult = OnMoveMsg(ptTopLeft, nativeMsg, bHandled);
+    SendWindowEvent(kWindowMoveMsg);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeShowWindowMsg(bool bShow, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnShowWindowMsg(bShow, nativeMsg, bHandled);
+    LRESULT lResult = OnShowWindowMsg(bShow, nativeMsg, bHandled);
+    SendWindowEvent(kWindowShowWindowMsg, bShow ? 1 : 0);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativePaintMsg(const UiRect& rcPaint, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnPaintMsg(rcPaint, nativeMsg, bHandled);
+    LRESULT lResult = OnPaintMsg(rcPaint, nativeMsg, bHandled);
+    SendWindowEvent(kWindowPaintMsg);
+
+    //首次绘制事件, 给一次回调
+    if (!IsWindowFirstShown()) {
+        m_bWindowFirstShown = true;
+
+        //触发第一次绘制事件
+        SendWindowEvent(kWindowFirstShown);
+    }
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeSetFocusMsg(INativeWindow* pLostFocusWindow, const NativeMsg& nativeMsg, bool& bHandled)
@@ -1012,7 +1055,9 @@ LRESULT WindowBase::OnNativeSetFocusMsg(INativeWindow* pLostFocusWindow, const N
     if (pLostFocusWindow != nullptr) {
         pLostFocusWindowBase = dynamic_cast<WindowBase*>(pLostFocusWindow);
     }
-    return OnSetFocusMsg(pLostFocusWindowBase, nativeMsg, bHandled);
+    LRESULT lResult = OnSetFocusMsg(pLostFocusWindowBase, nativeMsg, bHandled);
+    SendWindowEvent(kWindowSetFocusMsg, (WPARAM)pLostFocusWindowBase);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeKillFocusMsg(INativeWindow* pSetFocusWindow, const NativeMsg& nativeMsg, bool& bHandled)
@@ -1021,7 +1066,9 @@ LRESULT WindowBase::OnNativeKillFocusMsg(INativeWindow* pSetFocusWindow, const N
     if (pSetFocusWindow != nullptr) {
         pSetFocusWindowBase = dynamic_cast<WindowBase*>(pSetFocusWindow);
     }
-    return OnKillFocusMsg(pSetFocusWindowBase, nativeMsg, bHandled);
+    LRESULT lResult = OnKillFocusMsg(pSetFocusWindowBase, nativeMsg, bHandled);
+    SendWindowEvent(kWindowKillFocusMsg, (WPARAM)pSetFocusWindowBase);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeImeSetContextMsg(const NativeMsg& nativeMsg, bool& bHandled)
@@ -1046,7 +1093,9 @@ LRESULT WindowBase::OnNativeImeEndCompositionMsg(const NativeMsg& nativeMsg, boo
 
 LRESULT WindowBase::OnNativeSetCursorMsg(const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnSetCursorMsg(nativeMsg, bHandled);
+    LRESULT lResult = OnSetCursorMsg(nativeMsg, bHandled);
+    SendWindowEvent(kWindowSetCursorMsg);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeContextMenuMsg(const UiPoint& pt, const NativeMsg& nativeMsg, bool& bHandled)
@@ -1056,12 +1105,30 @@ LRESULT WindowBase::OnNativeContextMenuMsg(const UiPoint& pt, const NativeMsg& n
 
 LRESULT WindowBase::OnNativeKeyDownMsg(VirtualKeyCode vkCode, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnKeyDownMsg(vkCode, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnKeyDownMsg(vkCode, modifierKey, nativeMsg, bHandled);
+    if (!m_windowEventMap.empty()) {
+        EventArgs msg;
+        msg.SetSenderWeakFlag(GetWeakFlag());
+        msg.eventType = kWindowKeyDownMsg;
+        msg.vkCode = vkCode;
+        msg.modifierKey = modifierKey;
+        SendWindowEvent(msg);
+    }
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeKeyUpMsg(VirtualKeyCode vkCode, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnKeyUpMsg(vkCode, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnKeyUpMsg(vkCode, modifierKey, nativeMsg, bHandled);
+    if (!m_windowEventMap.empty()) {
+        EventArgs msg;
+        msg.SetSenderWeakFlag(GetWeakFlag());
+        msg.eventType = kWindowKeyUpMsg;
+        msg.vkCode = vkCode;
+        msg.modifierKey = modifierKey;
+        SendWindowEvent(msg);
+    }
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeCharMsg(VirtualKeyCode vkCode, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
@@ -1076,72 +1143,108 @@ LRESULT WindowBase::OnNativeHotKeyMsg(int32_t hotkeyId, VirtualKeyCode vkCode, u
 
 LRESULT WindowBase::OnNativeMouseWheelMsg(int32_t wheelDelta, const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseWheelMsg(wheelDelta, pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseWheelMsg(wheelDelta, pt, modifierKey, nativeMsg, bHandled);
+    if (!m_windowEventMap.empty()) {
+        EventArgs msg;
+        msg.SetSenderWeakFlag(GetWeakFlag());
+        msg.eventType = kWindowMouseWheelMsg;
+        msg.ptMouse = pt;
+        msg.modifierKey = modifierKey;
+        msg.eventData = wheelDelta;
+        SendWindowEvent(msg);
+    }
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseMoveMsg(const UiPoint& pt, uint32_t modifierKey, bool bFromNC, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseMoveMsg(pt, modifierKey, bFromNC, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseMoveMsg(pt, modifierKey, bFromNC, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowMouseMoveMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseHoverMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseHoverMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseHoverMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowMouseHoverMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseLeaveMsg(const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseLeaveMsg(nativeMsg, bHandled);
+    LRESULT lResult = OnMouseLeaveMsg(nativeMsg, bHandled);
+    SendWindowEvent(kWindowMouseLeaveMsg);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseLButtonDownMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseLButtonDownMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseLButtonDownMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowLButtonDownMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseLButtonUpMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseLButtonUpMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseLButtonUpMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowLButtonUpMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseLButtonDbClickMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseLButtonDbClickMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseLButtonDbClickMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowLButtonDbClickMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseRButtonDownMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseRButtonDownMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseRButtonDownMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowRButtonDownMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseRButtonUpMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseRButtonUpMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseRButtonUpMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowRButtonUpMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseRButtonDbClickMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseRButtonDbClickMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseRButtonDbClickMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowRButtonDbClickMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseMButtonDownMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseMButtonDownMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseMButtonDownMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowMButtonDownMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseMButtonUpMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseMButtonUpMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseMButtonUpMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowMButtonUpMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeMouseMButtonDbClickMsg(const UiPoint& pt, uint32_t modifierKey, const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnMouseMButtonDbClickMsg(pt, modifierKey, nativeMsg, bHandled);
+    LRESULT lResult = OnMouseMButtonDbClickMsg(pt, modifierKey, nativeMsg, bHandled);
+    SendWindowMouseEvent(kWindowMButtonDbClickMsg, pt, modifierKey);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeCaptureChangedMsg(const NativeMsg& nativeMsg, bool& bHandled)
 {
-    return OnCaptureChangedMsg(nativeMsg, bHandled);
+    LRESULT lResult = OnCaptureChangedMsg(nativeMsg, bHandled);
+    SendWindowEvent(kWindowCaptureChangedMsg);
+    return lResult;
 }
 
 LRESULT WindowBase::OnNativeWindowCloseMsg(uint32_t wParam, const NativeMsg& nativeMsg, bool& bHandled)
@@ -1152,6 +1255,213 @@ LRESULT WindowBase::OnNativeWindowCloseMsg(uint32_t wParam, const NativeMsg& nat
 void WindowBase::OnNativeWindowPosSnapped(bool bLeftSnap, bool bRightSnap, bool bTopSnap, bool bBottomSnap)
 {
     OnWindowPosSnapped(bLeftSnap, bRightSnap, bTopSnap, bBottomSnap);
+}
+
+bool WindowBase::IsWindowFirstShown() const
+{
+    return m_bWindowFirstShown;
+}
+
+bool WindowBase::SendWindowEvent(EventType eventType, WPARAM wParam, LPARAM lParam)
+{
+    if (m_windowEventMap.empty()) {
+        return true;
+    }
+    EventArgs msg;
+    msg.SetSenderWeakFlag(GetWeakFlag());
+    msg.eventType = eventType;
+    msg.ptMouse = GetLastMousePos();
+    msg.wParam = wParam;
+    msg.lParam = lParam;
+    return SendWindowEvent(msg);
+}
+
+bool WindowBase::SendWindowMouseEvent(EventType eventType, const UiPoint& pt, uint32_t modifierKey)
+{
+    if (m_windowEventMap.empty()) {
+        return true;
+    }
+    EventArgs msg;
+    msg.SetSenderWeakFlag(GetWeakFlag());
+    msg.eventType = eventType;
+    msg.ptMouse = pt;
+    msg.modifierKey = modifierKey;
+    return SendWindowEvent(msg);
+}
+
+bool WindowBase::SendWindowEvent(const EventArgs& msg)
+{
+    if (!m_windowEventMap.empty()) {
+        auto callback = m_windowEventMap.find(msg.eventType);
+        if (callback != m_windowEventMap.end()) {
+            callback->second(msg);
+        }
+    }
+    return true;
+}
+
+bool WindowBase::HasWindowEventCallback(EventType eventType) const
+{
+    return m_windowEventMap.find(eventType) != m_windowEventMap.end();
+}
+
+bool WindowBase::HasWindowEventCallbackByID(EventCallbackID callbackID) const
+{
+    for (auto iter = m_windowEventMap.begin(); iter != m_windowEventMap.end(); ++iter) {
+        if (iter->second.HasEventCallbackByID(callbackID)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void WindowBase::DetachWindowEventCallback(EventType eventType)
+{
+    auto iter = m_windowEventMap.find(eventType);
+    if (iter != m_windowEventMap.end()) {
+        m_windowEventMap.erase(iter);
+    }
+}
+
+void WindowBase::DetachWindowEventCallbackByID(EventCallbackID callbackID)
+{
+    EventUtils::RemoveEventCallbackByID(m_windowEventMap, callbackID);
+}
+
+void WindowBase::AttachWindowCreateMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowCreateMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowCloseMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowCloseMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowFirstShown(const EventCallback& callback, EventCallbackID callbackID)
+{
+    ASSERT(!IsWindowFirstShown());
+    m_windowEventMap[kWindowFirstShown].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowPosChangedMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowPosChangedMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowSizeMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowSizeMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMoveMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMoveMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowShowWindowMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowShowWindowMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowPaintMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowPaintMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowSetFocusMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowSetFocusMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowKillFocusMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowKillFocusMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowSetCursorMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowSetCursorMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowKeyDownMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowKeyDownMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowKeyUpMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowKeyUpMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMouseWheelMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMouseWheelMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMouseMoveMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMouseMoveMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMouseHoverMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMouseHoverMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMouseLeaveMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMouseLeaveMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowLButtonDownMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowLButtonDownMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowLButtonUpMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowLButtonUpMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowLButtonDbClickMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowLButtonDbClickMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowRButtonDownMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowRButtonDownMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowRButtonUpMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowRButtonUpMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowRButtonDbClickMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowRButtonDbClickMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMButtonDownMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMButtonDownMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMButtonUpMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMButtonUpMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowMButtonDbClickMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowMButtonDbClickMsg].AddEventCallback(callback, callbackID);
+}
+
+void WindowBase::AttachWindowCaptureChangedMsg(const EventCallback& callback, EventCallbackID callbackID)
+{
+    m_windowEventMap[kWindowCaptureChangedMsg].AddEventCallback(callback, callbackID);
 }
 
 } // namespace ui

--- a/duilib/Core/WindowBase.h
+++ b/duilib/Core/WindowBase.h
@@ -4,6 +4,7 @@
 #include "duilib/Core/INativeWindow.h"
 #include "duilib/Core/ControlPtrT.h"
 #include "duilib/Utils/FilePath.h"
+#include "duilib/Core/EventArgs.h"
 
 #if defined (DUILIB_BUILD_FOR_SDL)
     #include "duilib/Core/NativeWindow_SDL.h"
@@ -53,6 +54,10 @@ public:
     /** 是否含有有效的窗口句柄
     */
     bool IsWindow() const;
+
+    /** 当前窗口是不是子窗口（非弹出窗口类型的子窗口, 对于Windows系统，是只含有WS_CHILD风格的窗口）
+    */
+    bool IsChildWindow() const;
 
     /** 获取父窗口
     */
@@ -571,6 +576,196 @@ public:
     DString GetWindowRenderName() const;
 #endif
 
+    /** 界面是否完成首次显示
+    */
+    bool IsWindowFirstShown() const;
+
+public:
+    /** 监听窗口创建事件
+    * @param [in] callback 指定的回调函数，wParam是1表示为通过DoModal函数显示的模态对话框，wParam为0表示为普通窗口
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowCreateMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口关闭事件
+    * @param [in] callback 指定的回调函数，wParam是窗口关闭时的退出码
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowCloseMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口第一次显示事件（已完成界面布局设置）
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowFirstShown(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口位置大小变化事件
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowPosChangedMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口大小变化事件
+    * @param [in] callback 指定的回调函数, wParam是WindowSizeType类型的值
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowSizeMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口位置变化事件
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMoveMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口显示属性事件
+    * @param [in] callback 指定的回调函数, wParam为1表示显示，wParam为0表示隐藏
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowShowWindowMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口绘制事件
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowPaintMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口获取焦点事件
+    * @param [in] callback 指定的回调函数, wParam是失去焦点的窗口的指针(WindowBase*)
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowSetFocusMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口失去焦点事件
+    * @param [in] callback 指定的回调函数, wParam是获取焦点的窗口的指针(WindowBase*)
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowKillFocusMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口设置光标事件
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowSetCursorMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口键盘按下事件
+    * @param [in] callback 指定的回调函数: vkCode 虚拟键盘代码，modifierKey 按键标志位，有效值：ModifierKey::kFirstPress, ModifierKey::kAlt
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowKeyDownMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口键盘弹起事件
+    * @param [in] callback 指定的回调函数: vkCode 虚拟键盘代码，modifierKey 按键标志位，有效值：ModifierKey::kAlt
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowKeyUpMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标滚轮事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置
+    *                                    modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    *                                    eventData  滚轮旋转的距离，正值表示滚轮向前旋转（远离用户）；负值表示滚轮向后旋转（朝向用户）
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMouseWheelMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标移动事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMouseMoveMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标悬停事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMouseHoverMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标离开事件
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMouseLeaveMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标左键按下事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowLButtonDownMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标左键弹起事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowLButtonUpMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标左键双击事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowLButtonDbClickMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标右键按下事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowRButtonDownMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标右键弹起事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowRButtonUpMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标右键双击事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowRButtonDbClickMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标中键按下事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMButtonDownMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标中键弹起事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMButtonUpMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口鼠标中键双击事件
+    * @param [in] callback 指定的回调函数：ptMouse是鼠标所在位置，modifierKey 按键标志位，有效值：ModifierKey::kControl, ModifierKey::kShift
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowMButtonDbClickMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+    /** 监听窗口丢失鼠标捕获事件
+    * @param [in] callback 指定的回调函数
+    * @param [in] callbackID 该回调函数对应的ID（用于删除回调函数）
+    */
+    void AttachWindowCaptureChangedMsg(const EventCallback& callback, EventCallbackID callbackID = 0);
+
+public:
+    /** 本窗口是否含有回调函数（根据回调事件类型）
+    * @param [in] eventType 回调事件类型
+    */
+    bool HasWindowEventCallback(EventType eventType) const;
+
+    /** 本窗口是否含有回调函数（根据回调函数ID）
+    * @param [in] callbackID 该回调函数对应的ID
+    */
+    bool HasWindowEventCallbackByID(EventCallbackID callbackID) const;
+
+    /** 删除回调函数（根据回调事件类型）
+    * @param [in] eventType 回调事件类型
+    */
+    void DetachWindowEventCallback(EventType eventType);
+
+    /** 删除回调函数（根据回调函数ID）
+    * @param [in] callbackID 该回调函数对应的ID
+    */
+    void DetachWindowEventCallbackByID(EventCallbackID callbackID);
+
 protected:
     /** 正在初始化窗口数据
     */
@@ -722,7 +917,7 @@ protected:
     */
     virtual LRESULT OnMoveMsg(const UiPoint& ptTopLeft, const NativeMsg& nativeMsg, bool& bHandled) = 0;
 
-    /** 窗口绘制(WM_SHOWWINDOW)
+    /** 窗口显示或者隐藏(WM_SHOWWINDOW)
     * @param [in] bShow true表示窗口正在显示，false表示窗口正在隐藏
     * @param [in] nativeMsg 从系统接收到的原始消息内容
     * @param [out] bHandled 消息是否已经处理，返回 true 表明已经成功处理消息，不需要再传递给窗口过程；返回 false 表示将消息继续传递给窗口过程处理
@@ -1001,6 +1196,18 @@ protected:
     */
     void ClearWindowBase();
 
+    /** 主动发起一个消息(kWindowMsgBegin - kWindowMsgEnd), 发送给该窗口的事件回调管理器中注册的消息处理函数
+    * @param [in] eventType 转化后的消息体
+    * @param [in] wParam 消息附加参数
+    * @param [in] lParam 消息附加参数
+    * @param [in] pt 鼠标事件对应的坐标点
+    * @param [in] modifierKey 鼠标事件对应的键盘按键状态（有效值：ModifierKey::kControl, ModifierKey::kShift）
+    * @param [in] msg 消息内容
+    */
+    bool SendWindowEvent(EventType eventType, WPARAM wParam = 0, LPARAM lParam = 0);
+    bool SendWindowMouseEvent(EventType eventType, const UiPoint& pt, uint32_t modifierKey);
+    bool SendWindowEvent(const EventArgs& msg);
+
 private:
     /** 初始化窗口数据（内部函数，子类重写后，必须调用基类函数，否则影响功能）
     */
@@ -1103,6 +1310,13 @@ private:
     /** 窗口的实现类
     */
     NativeWindow* m_pNativeWindow;
+
+    /** 窗口的事件
+    */
+    EventMap m_windowEventMap;
+
+    //界面是否完成首次显示
+    bool m_bWindowFirstShown;
 };
 
 } // namespace ui

--- a/duilib/duilib_defs.h
+++ b/duilib/duilib_defs.h
@@ -124,6 +124,7 @@ namespace ui
     #define  DUI_CTR_ADDRESS_BAR                     (_T("AddressBar"))
     #define  DUI_CTR_ICON_CONTROL                    (_T("IconControl"))
     #define  DUI_CTR_BITMAP_CONTROL                  (_T("BitmapControl"))
+    #define  DUI_CTR_CHILD_WINDOW                    (_T("ChildWindow"))
 
     // 窗口标题栏按钮：最大化、最小化、关闭、还原、全屏窗口的名字，代码中写死的
     #define  DUI_CTR_CAPTION_BAR                     (_T("window_caption_bar"))
@@ -285,12 +286,14 @@ namespace ui
         bool m_bDecodeError;    //该图片是否存在数据解码错误
     };
 
-    //定义所有消息类型（注意事项：类型定义变化时，需要同步EventArgs.cpp中的InitEventStringMap函数，同步消息类型与消息名称的映射关系）
-    enum EventType: int8_t
+    //控件/窗口相关的消息类型（注意事项：类型定义变化时，除了窗口消息外，需要同步EventArgs.cpp中的InitEventStringMap函数，同步消息类型与消息名称的映射关系）
+    enum EventType: uint8_t
     {
-        kEventNone,
-        kEventAll,                  //代表所有消息（无参数关联数据）
-        kEventDestroy,              //控件销毁（最后一个消息）
+        /** 控件相关的消息
+        */
+        kEventNone,                 //空消息，控件消息的起始值
+        kEventAll,                  //代表所有控件消息（无参数关联数据）
+        kEventDestroy,              //控件销毁（控件生命周期内的最后一个消息）
 
         //键盘消息
         kEventKeyBegin,
@@ -335,7 +338,6 @@ namespace ui
         kEventWindowMove,           //Window类：发送给Focus控件，当窗口位置发生变化时触发事件        
         kEventWindowCreate,         //Window类，当窗口创建完成时触发，wParam为1表示DoModal对话框，为0表示普通窗口
         kEventWindowClose,          //Window类，Combo控件：当窗口关闭（或者Combo的下拉框窗口关闭）时触发，wParam参数表示窗口关闭参数，参见enum WindowCloseParam
-        kEventWindowFirstShown,     //Window类，当窗口第一次显示时回调此事件（必须在界面显示前设置回调，即当IsWindowFirstShown()返回false的情况下设置，否则没有机会再回调）
 
         //左键点击/右键点击事件
         kEventClick,                //Button类、ListBoxItem、Option、CheckBox等：当点击按钮（或者键盘回车）时触发
@@ -420,7 +422,39 @@ namespace ui
         kEventImageLoad,                //图片加载完成事件，wParam 为数据指针：ui::ImageDecodeResult*
         kEventImageDecode,              //图片解码完成事件，wParam 为数据指针：ui::ImageDecodeResult*
 
-        kEventLast                      //无使用者
+        kEventLast,                     //控件的最后一个消息
+
+        /** 窗口相关的事件，这些事件不会发给任何控件，直接发给应用层
+        */
+        kWindowMsgBegin,            //窗口消息的开始
+        kWindowCreateMsg,           //窗口创建消息
+        kWindowCloseMsg,            //窗口关闭消息
+        kWindowFirstShown,          //窗口第一次显示时回调此事件（必须在界面显示前设置回调，即当IsWindowFirstShown()返回false的情况下设置，否则没有机会再回调）
+        kWindowPosChangedMsg,       //窗口位置大小发生改变
+        kWindowSizeMsg,             //窗口大小发生改变
+        kWindowMoveMsg,             //窗口位置发生改变
+        kWindowShowWindowMsg,       //窗口显示或者隐藏
+        kWindowPaintMsg,            //窗口绘制
+        kWindowSetFocusMsg,         //窗口获得焦点
+        kWindowKillFocusMsg,        //窗口失去焦点
+        kWindowSetCursorMsg,        //窗口设置光标
+        kWindowKeyDownMsg,          //窗口中键盘按下
+        kWindowKeyUpMsg,            //窗口中键盘弹起
+        kWindowMouseWheelMsg,       //窗口中鼠标滚轮消息
+        kWindowMouseMoveMsg,        //窗口中鼠标移动消息
+        kWindowMouseHoverMsg,       //窗口中鼠标悬停消息
+        kWindowMouseLeaveMsg,       //窗口中鼠标离开消息
+        kWindowLButtonDownMsg,      //窗口中鼠标左键按下消息
+        kWindowLButtonUpMsg,        //窗口中鼠标左键弹起消息
+        kWindowLButtonDbClickMsg,   //窗口中鼠标左键双击消息
+        kWindowMButtonDownMsg,      //窗口中鼠标中键按下消息
+        kWindowMButtonUpMsg,        //窗口中鼠标中键弹起消息
+        kWindowMButtonDbClickMsg,   //窗口中鼠标中键双击消息
+        kWindowRButtonDownMsg,      //窗口中鼠标右键按下消息
+        kWindowRButtonUpMsg,        //窗口中鼠标右键弹起消息
+        kWindowRButtonDbClickMsg,   //窗口中鼠标右键双击消息
+        kWindowCaptureChangedMsg,   //窗口丢失鼠标捕获
+        kWindowMsgEnd               //窗口消息的结束
     };
 
     /** 热键组合键标志位
@@ -442,7 +476,6 @@ namespace ui
         kVkShift    = 0x0004, //MK_SHIFT,       //按下了 SHIFT 键
         kVkControl  = 0x0008  //MK_CONTROL,     //按下了 CTRL 键
     };
-
 }// namespace ui
 
 #endif //DUILIB_DEFS_H_

--- a/examples/CefBrowser/browser/BrowserForm.cpp
+++ b/examples/CefBrowser/browser/BrowserForm.cpp
@@ -167,7 +167,7 @@ public:
 void BrowserForm::OnInitWindow()
 {
     TestApplication::Instance().AddMainWindow(this);
-    AttachWindowSetFocus([this](const ui::EventArgs&) {
+    AttachWindowSetFocusMsg([this](const ui::EventArgs&) {
         TestApplication::Instance().SetActiveMainWindow(this);
         return true;
         });

--- a/examples/RichEdit/MainForm.cpp
+++ b/examples/RichEdit/MainForm.cpp
@@ -1026,7 +1026,7 @@ void MainForm::OnFindText()
         createParam.m_bCenterWindow = true;
         m_pFindForm->CreateWnd(this, createParam);
         m_pFindForm->ShowWindow(ui::kSW_SHOW);
-        m_pFindForm->AttachWindowClose([this](const ui::EventArgs& args) {
+        m_pFindForm->AttachWindowCloseMsg([this](const ui::EventArgs& args) {
                 m_pFindForm = nullptr;
                 return true;
             });
@@ -1057,7 +1057,7 @@ void MainForm::OnReplaceText()
         createParam.m_bCenterWindow = true;
         m_pReplaceForm->CreateWnd(this, createParam);
         m_pReplaceForm->ShowWindow(ui::kSW_SHOW);
-        m_pReplaceForm->AttachWindowClose([this](const ui::EventArgs& args) {
+        m_pReplaceForm->AttachWindowCloseMsg([this](const ui::EventArgs& args) {
                 m_pReplaceForm = nullptr;
                 return true;
             });

--- a/examples/WebView2Browser/BrowserForm.cpp
+++ b/examples/WebView2Browser/BrowserForm.cpp
@@ -163,7 +163,7 @@ public:
 void BrowserForm::OnInitWindow()
 {
     TestApplication::Instance().AddMainWindow(this);
-    AttachWindowSetFocus([this](const ui::EventArgs&) {
+    AttachWindowSetFocusMsg([this](const ui::EventArgs&) {
         TestApplication::Instance().SetActiveMainWindow(this);
         return true;
         });

--- a/examples/cef/CefForm.cpp
+++ b/examples/cef/CefForm.cpp
@@ -92,7 +92,7 @@ void CefForm::OnInitWindow()
 
     if (!ui::CefManager::GetInstance()->IsEnableOffScreenRendering()) {
         //处理控件多焦点问题（由于cef控件是子窗口模式，duilib内部无法自己完成这个功能）
-        AttachWindowKillFocus([this](const ui::EventArgs& args) {
+        AttachWindowKillFocusMsg([this](const ui::EventArgs& args) {
             //当窗口失去焦点的时候，让界面中的控件失去焦点，避免出现网页与界面控件同时处于焦点状态的问题
             KillFocusControl();
             return true;

--- a/examples/controls/ControlForm.cpp
+++ b/examples/controls/ControlForm.cpp
@@ -390,7 +390,7 @@ void ControlForm::ShowColorPicker(bool bDoModal)
         }
         return true;
         };
-    pColorPicker->AttachWindowCreate(OnInitColorPicker);
+    pColorPicker->AttachWindowCreateMsg(OnInitColorPicker);
 
     ui::WindowCreateParam createParam;
     createParam.m_dwStyle = ui::kWS_POPUP;


### PR DESCRIPTION
1. 补充ListBoxItem的属性描述文档
2. 窗口事件相关的结构调整：窗口的事件与控件的事件分开管理，避免混淆；窗口的事件统一放在WindowBase里面管理。
