### PR TITLE
修复macOS平台的编译错误：ControlResizable.h:488:1: error: missing 'typename' pr…

### DIFF
--- a/duilib/Core/ControlResizable.h
+++ b/duilib/Core/ControlResizable.h
@@ -485,7 +485,7 @@ void ControlResizableT<T>::ResizeMouseUp(const EventArgs& msg)
 }
 
 template<typename T>
-ControlResizableT<T>::SizeType ControlResizableT<T>::GetCurrentSizeType(const UiPoint& ptMouse) const
+typename ControlResizableT<T>::SizeType ControlResizableT<T>::GetCurrentSizeType(const UiPoint& ptMouse) const
 {
     UiPoint pt(ptMouse);
     pt.Offset(this->GetScrollOffsetInScrollBox());


### PR DESCRIPTION
修复macOS平台的编译错误
