### PR TITLE
(#353)CEF模块：修复CefJSBridge类中，RenderRegisteredFunction/BrowserRegistere…

### DIFF
--- a/duilib/CEFControl/internal/CefJSBridge.h
+++ b/duilib/CEFControl/internal/CefJSBridge.h
@@ -1,25 +1,13 @@
 #ifndef UI_CEF_CONTROL_CEF_JS_BRIDGE_H_
 #define UI_CEF_CONTROL_CEF_JS_BRIDGE_H_
 
-#include "duilib/CEFControl/CefControlEvent.h"
-
-#pragma warning (push)
-#pragma warning (disable:4100)
-    #include "include/cef_v8.h"
-    #include "include/cef_version.h"
-#pragma warning (pop)
-
-#include <functional>
-#include <map>
+#include "duilib/CEFControl/internal/CefRegisteredFunctions.h"
 
 namespace ui
 {
 
 typedef std::map<int/* js_callback_id*/, std::pair<CefRefPtr<CefV8Context>/* context*/, CefRefPtr<CefV8Value>/* callback*/>> RenderCallbackMap;
 typedef std::map<int/* cpp_callback_id*/, CallJsFunctionCallback/* callback*/> BrowserCallbackMap;
-
-typedef std::map<std::pair<CefString/* function_name*/, CefString/* frame_id*/>, CefRefPtr<CefV8Value>/* function*/> RenderRegisteredFunction;
-typedef std::map<std::pair<CefString/* function_name*/, int64_t/* browser_id*/>, CppFunction/* function*/> BrowserRegisteredFunction;
 
 class CefJSBridge
 {
@@ -29,104 +17,93 @@ public:
 
 // in render process
 public:
-    /**
-     * 执行已经注册好的 C++ 方法
-     * param[in] function_name    要调用的函数名称
-     * param[in] params            调用该函数传递的 json 格式参数
-     * param[in] callback        执行完成后的结果回调函数
+    /** 执行已经注册好的 C++ 方法
+     * param [in] function_name 要调用的函数名称
+     * param [in] params 调用该函数传递的 json 格式参数
+     * param [in] callback 执行完成后的结果回调函数
      * return 返回 true 表示发起执行请求成功（并不代表一定执行成功，具体看回调），返回 false 可能是注册的回调函数 ID 已经存在
      */
     bool CallCppFunction(const CefString& function_name, const CefString& params, CefRefPtr<CefV8Value> callback);
 
     /**
      * 通过判断上下文环境移除指定回调函数（页面刷新会触发该方法）
-     * param[in] frame        当前运行框架
+     * param [in] frame 当前运行框架
      */
     void RemoveCallbackFuncWithFrame(CefRefPtr<CefFrame> frame);
 
-    /**
-     * 根据 ID 执行指定回调函数
-     * param[in] js_callback_id    回调函数的 ID
-     * param[in] has_error        是否有错误，对应回调函数第一个参数
-     * param[in] json_string    如果没有错误则返回指定的 json string 格式的数据，对应回调函数第二个参数
+    /** 根据 ID 执行指定回调函数
+     * param [in] js_callback_id 回调函数的 ID
+     * param [in] has_error 是否有错误，对应回调函数第一个参数
+     * param [in] json_string 如果没有错误则返回指定的 json string 格式的数据，对应回调函数第二个参数
      * return 返回 true 表示成功执行了回调函数，返回 false 有可能回调函数不存在或者回调函数所需的执行上下文环境已经不存在
      */
     bool ExecuteJSCallbackFunc(int js_callback_id, bool has_error, const CefString& json_result);
 
-    /**
-     * 注册一个持久的 JS 函数提供 C++ 调用
-     * param[in] function_name    函数名称，字符串形式提供 C++ 直接调用，名称不能重复
-     * param[in] context        函数的执行上下文环境
-     * param[in] function        函数体
-     * param[in] replace        若已经存在该名称的函数是否替换，默认否
+    /** 注册一个持久的 JS 函数提供 C++ 调用
+     * param [in] function_name 函数名称，字符串形式提供 C++ 直接调用，名称不能重复
+     * param [in] context 函数的执行上下文环境
+     * param [in] function 函数体
+     * param [in] replace 若已经存在该名称的函数是否替换，默认否
      * return replace 为 true 的情况下，返回 true 是替换成功，返回 false 为不可预见行为。replace 为 false 的情况下返回 true 表示注册成功，返回 false 是同名函数已经注册过了。
      */
     bool RegisterJSFunc(const CefString& function_name, CefRefPtr<CefV8Value> function, bool replace = false);
 
-    /**
-     * 反注册一个持久的 JS 函数
-     * param[in] function_name    函数名称
-     * param[in] frame            要取消注册哪个框架下的相关函数
+    /** 反注册一个持久的 JS 函数
+     * param [in] function_name 函数名称
+     * param [in] frame 要取消注册哪个框架下的相关函数
      */
     void UnRegisterJSFunc(const CefString& function_name, CefRefPtr<CefFrame> frame);
 
-    /**
-    * 根据执行上下文反注册一个或多个持久的 JS 函数
-    * param[in] frame            当前运行所属框架
+    /** 根据执行上下文反注册一个或多个持久的 JS 函数
+    * param [in] frame 当前运行所属框架
     */
     void UnRegisterJSFuncWithFrame(CefRefPtr<CefFrame> frame);
 
-    /**
-     * 根据名称执行某个具体的 JS 函数
-     * param[in] function_name    函数名称
-     * param[in] json_params    要传递的 json 格式的参数
-     * param[in] frame            执行哪个框架下的 JS 函数
-     * param[in] cpp_callback_id    执行完成后要回调的 C++ 回调函数 ID
+    /** 根据名称执行某个具体的 JS 函数
+     * param [in] function_name    函数名称
+     * param [in] json_params    要传递的 json 格式的参数
+     * param [in] frame            执行哪个框架下的 JS 函数
+     * param [in] cpp_callback_id    执行完成后要回调的 C++ 回调函数 ID
      * return 返回 true 表示成功执行某个 JS 函数，返回 false 有可能要执行的函数不存在或者该函数的运行上下文已经无效
      */
     bool ExecuteJSFunc(const CefString& function_name, const CefString& json_params, CefRefPtr<CefFrame> frame, int cpp_callback_id);
 
 // in browser process
 public:
-    /**
-     * 执行已经注册好的 JS 方法
-     * param[in] js_function_name 要调用的 JS 函数名称
-     * param[in] params            调用 JS 方法传递的 json 格式参数
-     * param[in] frame            调用哪个框架下的 JS 代码
-     * param[in] callback        调用 JS 方法后返回数据的回调函数
+    /** 执行已经注册好的 JS 方法
+     * param [in] js_function_name 要调用的 JS 函数名称
+     * param [in] params 调用 JS 方法传递的 json 格式参数
+     * param [in] frame 调用哪个框架下的 JS 代码
+     * param [in] callback 调用 JS 方法后返回数据的回调函数
      * return 返回 ture 标识发起执行 JS 函数命令成功，返回 false 是相同的 callback id 已经存在
      */
     bool CallJSFunction(const CefString& js_function_name, const CefString& params, CefRefPtr<CefFrame> frame, CallJsFunctionCallback callback);
 
-    /**
-     * 根据 ID 执行指定回调函数
-     * param[in] cpp_callback_id callback 函数的 id
-     * param[in] json_string    返回的 json 格式数据
+    /** 根据 ID 执行指定回调函数
+     * param [in] cpp_callback_id callback 函数的 id
+     * param [in] json_string 返回的 json 格式数据
      * return 返回 true 执行成功，false 为执行失败，可能回调不存在
      */
     bool ExecuteCppCallbackFunc(int cpp_callback_id, const CefString& json_string);
 
-    /**
-     * 注册一个持久的 C++ 函数提供 JS 端调用
-     * param[in] function_name    要提供 JS 调用的函数名字
-     * param[in] function        函数体
-     * param[in] replace        是否替换相同名称的函数体，默认不替换
+    /** 注册一个持久的 C++ 函数提供 JS 端调用
+     * param[in] function_name 要提供 JS 调用的函数名字
+     * param[in] function 函数体
+     * param[in] replace 是否替换相同名称的函数体，默认不替换
      * return replace 为 true 的情况下，返回 true 表示注册或者替换成功，false 是不可预知行为。replace 为 false 的情况下返回 true 表示注册成功，返回 false 表示函数名已经注册
      */
     bool RegisterCppFunc(const CefString& function_name, CppFunction function, CefRefPtr<CefBrowser> browser, bool  replace = false);
 
-    /**
-     * 反注册一个持久的 C++ 函数
+    /** 反注册一个持久的 C++ 函数
      * param[in] function_name    要反注册的函数名称
      */
     void UnRegisterCppFunc(const CefString& function_name, CefRefPtr<CefBrowser> browser);
 
-    /**
-     * 执行一个已经注册好的 C++ 方法（接受到 JS 端执行请求时被调用）
-     * param[in] function_name    要执行的函数名称
-     * param[in] params            携带的参数
-     * param[in] js_callback_id    回调 JS 端所需的回调函数 ID
-     * param[in] browser        browser 实例句柄
+    /** 执行一个已经注册好的 C++ 方法（接受到 JS 端执行请求时被调用）
+     * param [in] function_name 要执行的函数名称
+     * param [in] params 携带的参数
+     * param [in] js_callback_id 回调 JS 端所需的回调函数 ID
+     * param [in] browser browser 实例句柄
      * return 返回 true 表示执行成功，返回 false 表示执行失败，函数名可能不存在
      */
     bool ExecuteCppFunc(const CefString& function_name, const CefString& params, int js_callback_id, CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame);
@@ -137,23 +114,23 @@ public:
     static CefString Int64ToCefString(int64_t nValue);
 
 private:
-    // JS 端回调函数?索引计数
+    // JS 端回调函数的索引计数
     uint32_t m_jsCallbackId = 0;
      
-    // C++ 端回调函??的索引计数
+    // C++ 端回调函数的索引计数
     uint32_t m_cppCallbackId = 0;
 
-    // JS 端回调函数的对??列表
+    // JS 端回调函数的对列表
     RenderCallbackMap m_renderCallbackMap;
     
-    // C++ 端回调函数的对?列表
+    // C++ 端回调函数的对列表
     BrowserCallbackMap m_browserCallbackMap;
 
-    // 保存 JS 端已经注册??的持久函数列表
-    RenderRegisteredFunction m_renderRegisteredFunction; 
+    // 保存 JS 端已经注册的持久函数列表
+    RenderRegisteredFunctions m_renderRegisteredFunctions; 
     
-    // 保存 C++ 端已经注册?的持久函数列表
-    BrowserRegisteredFunction m_browserRegisteredFunction;
+    // 保存 C++ 端已经注册的持久函数列表
+    BrowserRegisteredFunctions m_browserRegisteredFunctions;
 };
 
 }

--- a/duilib/CEFControl/internal/CefRegisteredFunctions.cpp
+++ b/duilib/CEFControl/internal/CefRegisteredFunctions.cpp
@@ -1,0 +1,206 @@
+#include "CefRegisteredFunctions.h"
+#include "duilib/Utils/StringUtil.h"
+
+namespace ui
+{
+bool RenderRegisteredFunctions::AddJsFunction(const CefString& function_name, const CefString& frame_id,
+                                              const CefRefPtr<CefV8Value>& function, bool enable_replace)
+{
+    ASSERT(!function_name.empty() && !frame_id.empty() && (function != nullptr));
+    if (function_name.empty() || frame_id.empty() || (function == nullptr)) {
+        return false;
+    }
+    bool bRet = true;
+    FrameFunctionMap& frameFunctionMap = m_renderJsFunctionMap[function_name];
+    auto iter = frameFunctionMap.find(frame_id);
+    if (iter != frameFunctionMap.end()) {
+        //已经存在
+        if (enable_replace) {
+            frameFunctionMap[frame_id] = function; //允许覆盖
+        }
+        else {
+            bRet = false;//不允许覆盖
+        }
+    }
+    else {
+        //不存在, 添加
+        frameFunctionMap[frame_id] = function;
+    }
+    return bRet;
+}
+
+CefRefPtr<CefV8Value> RenderRegisteredFunctions::FindJsFunction(const CefString& function_name, const CefString& frame_id)
+{
+    CefRefPtr<CefV8Value> function = nullptr;
+    auto iter = m_renderJsFunctionMap.find(function_name);
+    if (iter != m_renderJsFunctionMap.end()) {
+        const FrameFunctionMap& frameFunctionMap = iter->second;
+        auto pos = frameFunctionMap.find(frame_id);
+        if (pos != frameFunctionMap.end()) {
+            function = pos->second;
+        }
+    }
+    return function;
+}
+
+void RenderRegisteredFunctions::RemoveJsFunction(const CefString& function_name)
+{
+    auto iter = m_renderJsFunctionMap.find(function_name);
+    if (iter != m_renderJsFunctionMap.end()) {
+        m_renderJsFunctionMap.erase(iter);
+    }
+}
+
+void RenderRegisteredFunctions::RemoveJsFunction(const CefString& function_name, const CefString& frame_id)
+{
+    auto iter = m_renderJsFunctionMap.find(function_name);
+    if (iter != m_renderJsFunctionMap.end()) {
+        FrameFunctionMap& frameFunctionMap = iter->second;
+        auto pos = frameFunctionMap.find(frame_id);
+        if (pos != frameFunctionMap.end()) {
+            frameFunctionMap.erase(pos);
+        }
+        if (frameFunctionMap.empty()) {
+            m_renderJsFunctionMap.erase(iter);
+        }
+    }
+}
+
+void RenderRegisteredFunctions::RemoveJsFunctionByFrameId(const CefString& frame_id)
+{
+    auto iter = m_renderJsFunctionMap.begin();
+    while (iter != m_renderJsFunctionMap.end()) {
+        FrameFunctionMap& frameFunctionMap = iter->second;
+        auto pos = frameFunctionMap.find(frame_id);
+        if (pos != frameFunctionMap.end()) {
+            frameFunctionMap.erase(pos);
+        }
+        if (frameFunctionMap.empty()) {
+            iter = m_renderJsFunctionMap.erase(iter);
+        }
+        else {
+            ++iter;
+        }
+    }
+}
+
+void RenderRegisteredFunctions::RemoveJsFunctionByFrame(CefRefPtr<CefFrame> frame)
+{
+    ASSERT(frame != nullptr);
+    if (frame == nullptr) {
+        return;
+    }
+
+    // 由于本类中每一个 render 和 browser 进程都独享一份实例，而不是单例模式
+    // 所以这里获取的 browser 都是全局唯一的，可以根据这个 browser 获取所有 frame 和 context
+    auto browser = frame->GetBrowser();
+    ASSERT(browser != nullptr);
+    if (browser == nullptr) {
+        return;
+    }
+
+    if (!m_renderJsFunctionMap.empty()) {
+        for (auto iter = m_renderJsFunctionMap.begin(); iter != m_renderJsFunctionMap.end();) {
+            FrameFunctionMap& frameFunctionMap = iter->second;            
+            for (auto pos = frameFunctionMap.begin(); pos != frameFunctionMap.end();) {
+#if CEF_VERSION_MAJOR <= 109
+                //CEF 109版本
+                int64 identifier = StringUtil::StringToInt64(pos->first.c_str());
+                auto child_frame = browser->GetFrame(identifier);
+#else
+                //CEF 高版本
+                auto child_frame = browser->GetFrameByIdentifier(pos->first);
+#endif
+                if (child_frame.get() && child_frame->GetV8Context()->IsSame(frame->GetV8Context())) {
+                    pos = frameFunctionMap.erase(pos);
+                }
+                else {
+                    ++pos;
+                }
+            }
+
+            if (frameFunctionMap.empty()) {
+                iter = m_renderJsFunctionMap.erase(iter);
+            }
+            else {
+                ++iter;
+            }
+        }
+    }
+}
+
+void RenderRegisteredFunctions::ClearAllJsFunctions()
+{
+    m_renderJsFunctionMap.clear();
+}
+
+/////////////////////////////////////////////////////////////
+bool BrowserRegisteredFunctions::AddCppFunction(const CefString& function_name, int64_t browser_id,
+                                                CppFunction function, bool enable_replace)
+{
+    ASSERT(!function_name.empty() && (function != nullptr));
+    if (function_name.empty() || (function == nullptr)) {
+        return false;
+    }
+    bool bRet = true;
+    BrowserFunctionMap& browserFunctionMap = m_browserCppFunctionMap[function_name];
+    auto iter = browserFunctionMap.find(browser_id);
+    if (iter != browserFunctionMap.end()) {
+        //已经存在
+        if (enable_replace) {
+            browserFunctionMap[browser_id] = function; //允许覆盖
+        }
+        else {
+            bRet = false;//不允许覆盖
+        }
+    }
+    else {
+        //不存在, 添加
+        browserFunctionMap[browser_id] = function;
+    }
+    return bRet;
+}
+
+CppFunction BrowserRegisteredFunctions::FindCppFunction(const CefString& function_name, int64_t browser_id)
+{
+    CppFunction function = nullptr;
+    auto iter = m_browserCppFunctionMap.find(function_name);
+    if (iter != m_browserCppFunctionMap.end()) {
+        const BrowserFunctionMap& browserFunctionMap = iter->second;
+        auto pos = browserFunctionMap.find(browser_id);
+        if (pos != browserFunctionMap.end()) {
+            function = pos->second;
+        }
+    }
+    return function;
+}
+
+void BrowserRegisteredFunctions::RemoveCppFunction(const CefString& function_name)
+{
+    auto iter = m_browserCppFunctionMap.find(function_name);
+    if (iter != m_browserCppFunctionMap.end()) {
+        m_browserCppFunctionMap.erase(iter);
+    }
+}
+
+void BrowserRegisteredFunctions::RemoveCppFunction(const CefString& function_name, int64_t browser_id)
+{
+    auto iter = m_browserCppFunctionMap.find(function_name);
+    if (iter != m_browserCppFunctionMap.end()) {
+        BrowserFunctionMap& browserFunctionMap = iter->second;
+        auto pos = browserFunctionMap.find(browser_id);
+        if (pos != browserFunctionMap.end()) {
+            browserFunctionMap.erase(pos);
+        }
+        if (browserFunctionMap.empty()) {
+            m_browserCppFunctionMap.erase(iter);
+        }
+    }
+}
+
+void BrowserRegisteredFunctions::ClearAllCppFunctions()
+{
+    m_browserCppFunctionMap.clear();
+}
+
+} //namespace ui

--- a/duilib/CEFControl/internal/CefRegisteredFunctions.h
+++ b/duilib/CEFControl/internal/CefRegisteredFunctions.h
@@ -1,0 +1,115 @@
+#ifndef UI_CEF_CONTROL_CEF_REGISTERED_FUNCTIONS_H_
+#define UI_CEF_CONTROL_CEF_REGISTERED_FUNCTIONS_H_
+
+#include "duilib/CEFControl/CefControlEvent.h"
+
+#pragma warning (push)
+#pragma warning (disable:4100)
+    #include "include/cef_v8.h"
+    #include "include/cef_version.h"
+#pragma warning (pop)
+
+#include <functional>
+#include <map>
+
+namespace ui
+{
+/** Render：注册一个JS函数
+*/
+class RenderRegisteredFunctions
+{
+public:
+    /** 添加一个JS函数
+     * @param [in] function_name 函数名称
+     * @param [in] frame_id CefFrame对象的ID
+     * @param [in] function 注册的JS函数
+     * @param [in] enable_replace 是否允许覆盖
+     */
+    bool AddJsFunction(const CefString& function_name, const CefString& frame_id,
+                       const CefRefPtr<CefV8Value>& function, bool enable_replace);
+
+    /** 查找一个已经注册的JS函数
+     * @param [in] function_name 函数名称
+     * @param [in] frame_id CefFrame对象的ID
+     */
+    CefRefPtr<CefV8Value> FindJsFunction(const CefString& function_name, const CefString& frame_id);
+
+    /** 删除已经注册JS函数
+    * @param [in] function_name 函数名称
+    */
+    void RemoveJsFunction(const CefString& function_name);
+
+    /** 删除已经注册JS函数
+    * @param [in] function_name 函数名称
+    * @param [in] frame_id CefFrame对象的ID
+    */
+    void RemoveJsFunction(const CefString& function_name, const CefString& frame_id);
+
+    /** 删除已经注册JS函数
+    * @param [in] frame_id CefFrame对象的ID
+    */
+    void RemoveJsFunctionByFrameId(const CefString& frame_id);
+
+    /** 删除已经注册JS函数
+    * @param [in] frame CefFrame对象
+    */
+    void RemoveJsFunctionByFrame(CefRefPtr<CefFrame> frame);
+
+    /** 清除所有的已注册函数
+    */
+    void ClearAllJsFunctions();
+
+private:
+    typedef std::map<CefString/* frame_id*/, CefRefPtr<CefV8Value>/* function*/> FrameFunctionMap;
+    typedef std::map<CefString/* function_name*/, FrameFunctionMap> RenderRegisteredFunctionMap;
+
+    //函数映射表
+    RenderRegisteredFunctionMap m_renderJsFunctionMap;
+};
+
+/** Browser：注册一个Cpp函数
+*/
+class BrowserRegisteredFunctions
+{
+public:
+    /** 添加一个JS函数
+     * @param [in] function_name 函数名称
+     * @param [in] browser_id Browser对象的ID
+     * @param [in] function 注册的Cpp函数
+     * @param [in] enable_replace 是否允许覆盖
+     */
+    bool AddCppFunction(const CefString& function_name, int64_t browser_id,
+                        CppFunction function, bool enable_replace);
+
+    /** 查找一个已经注册的Cpp函数
+     * @param [in] function_name 函数名称
+     * @param [in] browser_id Browser对象的ID
+     */
+    CppFunction FindCppFunction(const CefString& function_name, int64_t browser_id);
+
+    /** 删除已经注册Cpp函数
+    * @param [in] function_name 函数名称
+    */
+    void RemoveCppFunction(const CefString& function_name);
+
+    /** 删除已经注册Cpp函数
+    * @param [in] function_name 函数名称
+    * @param [in] browser_id Browser对象的ID
+    */
+    void RemoveCppFunction(const CefString& function_name, int64_t browser_id);
+
+    /** 清除所有的已注册函数
+    */
+    void ClearAllCppFunctions();
+
+private:
+    typedef std::map<int64_t/*browser_id*/, CppFunction/* function*/> BrowserFunctionMap;
+    typedef std::map<CefString/* function_name*/, BrowserFunctionMap> BrowserRegisteredFunctionMap;
+
+    //函数映射表
+    BrowserRegisteredFunctionMap m_browserCppFunctionMap;
+};
+
+}//namespace ui
+
+#endif //UI_CEF_CONTROL_CEF_REGISTERED_FUNCTIONS_H_

--- a/duilib/duilib.vcxproj
+++ b/duilib/duilib.vcxproj
@@ -246,6 +246,7 @@
     <ClCompile Include="CEFControl\internal\CefJSBridge.cpp" />
     <ClCompile Include="CEFControl\internal\CefJsHandler.cpp" />
     <ClCompile Include="CEFControl\internal\CefMemoryBlock.cpp" />
+    <ClCompile Include="CEFControl\internal\CefRegisteredFunctions.cpp" />
     <ClCompile Include="CEFControl\internal\Windows\bytes_write_handler.cc" />
     <ClCompile Include="CEFControl\internal\Windows\CefOsrDropTarget.cpp" />
     <ClCompile Include="CEFControl\internal\Windows\osr_dragdrop_win.cc" />
@@ -586,6 +587,7 @@
     <ClInclude Include="CEFControl\internal\CefJSBridge.h" />
     <ClInclude Include="CEFControl\internal\CefJsHandler.h" />
     <ClInclude Include="CEFControl\internal\CefMemoryBlock.h" />
+    <ClInclude Include="CEFControl\internal\CefRegisteredFunctions.h" />
     <ClInclude Include="CEFControl\internal\osr_dragdrop_events.h" />
     <ClInclude Include="CEFControl\internal\Windows\bytes_write_handler.h" />
     <ClInclude Include="CEFControl\internal\Windows\CefOsrDropTarget.h" />

--- a/duilib/duilib.vcxproj.filters
+++ b/duilib/duilib.vcxproj.filters
@@ -867,6 +867,9 @@
     <ClCompile Include="Box\XmlBox.cpp">
       <Filter>Box</Filter>
     </ClCompile>
+    <ClCompile Include="CEFControl\internal\CefRegisteredFunctions.cpp">
+      <Filter>CEFControl\internal</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Animation\AnimationManager.h">
@@ -1801,6 +1804,9 @@
     </ClInclude>
     <ClInclude Include="Box\XmlBox.h">
       <Filter>Box</Filter>
+    </ClInclude>
+    <ClInclude Include="CEFControl\internal\CefRegisteredFunctions.h">
+      <Filter>CEFControl\internal</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
CEF模块：修复CefJSBridge类中，RenderRegisteredFunction/BrowserRegisteredFunction两个使用std::map的容器在KEY设计方面的错误（使用std::pair<CefString,CefString>和std::pair<CefString,int64_t>为KEY的类型，这个不能保证查找是正确的）。
