### PR TITLE
TreeNode的一系列缺陷修复

### DIFF
--- a/bin/resources/themes/default/controls/controls.xml
+++ b/bin/resources/themes/default/controls/controls.xml
@@ -60,7 +60,7 @@
                     <TreeNode class="listitem" height="20" text="ui::TreeView Parent Node 0"/>
                     <TreeNode class="listitem" height="20" text="ui::TreeView Parent Node 1">
                         <TreeNode class="listitem" height="20" text="ui::TreeView::TreeNode 1-1"/>
-                        <TreeNode class="listitem" height="20" text="ui::TreeView::TreeNode 1-3"/>
+                        <TreeNode class="listitem" height="20" text="ui::TreeView::TreeNode 1-2"/>
                         <TreeNode class="listitem" height="20" text="ui::TreeView::TreeNode 1-3">
                             <TreeNode class="listitem" height="20" text="ui::TreeView::TreeNode 1-3-1"/>
                             <TreeNode class="listitem" height="20" text="ui::TreeView::TreeNode 1-3-2">

--- a/duilib/Control/Label.h
+++ b/duilib/Control/Label.h
@@ -88,6 +88,10 @@ public:
     */
     bool IsRichText() const;
 
+    /** 判断文本是否相等
+    */
+    bool IsTextEquals(const DString& text) const;
+
 public:
     /** 恢复默认的文本样式
     * @param [in] bRedraw true表示重绘，false表示不重绘
@@ -493,6 +497,12 @@ template<typename T>
 bool LabelTemplate<T>::IsRichText() const
 {
     return m_impl->IsRichText();
+}
+
+template<typename T>
+bool LabelTemplate<T>::IsTextEquals(const DString& text) const
+{
+    return m_impl->IsTextEquals(text);
 }
 
 template<typename T>

--- a/duilib/Control/LabelImpl.cpp
+++ b/duilib/Control/LabelImpl.cpp
@@ -390,6 +390,16 @@ bool LabelImpl::IsRichText() const
     return m_bRichText;
 }
 
+bool LabelImpl::IsTextEquals(const DString& text) const
+{
+    if (m_sText.empty() && !m_sTextId.empty()) {
+        return StringUtil::StringCompare(GetText().c_str(), text.c_str()) == 0;
+    }
+    else {
+        return StringUtil::StringCompare(m_sText.c_str(), text.c_str()) == 0;
+    }
+}
+
 DString LabelImpl::GetOwnerText() const
 {
     LabelOwner* pLabelOwner = dynamic_cast<LabelOwner*>(m_pOwner);

--- a/duilib/Control/LabelImpl.h
+++ b/duilib/Control/LabelImpl.h
@@ -111,6 +111,10 @@ public:
     */
     bool IsRichText() const;
 
+    /** 判断文本是否相等
+    */
+    bool IsTextEquals(const DString& text) const;
+
 public:
     /** 恢复默认的文本样式
     * @param [in] bRedraw true表示重绘，false表示不重绘

--- a/duilib/Control/TreeView.cpp
+++ b/duilib/Control/TreeView.cpp
@@ -1046,6 +1046,54 @@ void TreeNode::GetChildNodes(std::vector<TreeNode*>& childNodes) const
     }
 }
 
+TreeNode* TreeNode::FindChildNodeByName(const DString& name, bool bRecursive) const
+{
+    for (TreeNode* pNode : m_aTreeNodes) {
+        if (pNode != nullptr) {
+            if (pNode->IsNameEquals(name)) {
+                return pNode;
+            }
+        }
+    }
+    if (!bRecursive) {
+        return nullptr;
+    }
+    //递归查找，孙节点等多级子节点
+    for (TreeNode* pNode : m_aTreeNodes) {
+        if (pNode != nullptr) {
+            TreeNode* pFoundNode = pNode->FindChildNodeByName(name, bRecursive);
+            if (pFoundNode != nullptr) {
+                return pFoundNode;
+            }
+        }
+    }
+    return nullptr;
+}
+
+TreeNode* TreeNode::FindChildNodeByText(const DString& text, bool bRecursive) const
+{
+    for (TreeNode* pNode : m_aTreeNodes) {
+        if (pNode != nullptr) {
+            if (pNode->IsTextEquals(text)) {
+                return pNode;
+            }
+        }
+    }
+    if (!bRecursive) {
+        return nullptr;
+    }
+    //递归查找，孙节点等多级子节点
+    for (TreeNode* pNode : m_aTreeNodes) {
+        if (pNode != nullptr) {
+            TreeNode* pFoundNode = pNode->FindChildNodeByText(text, bRecursive);
+            if (pFoundNode != nullptr) {
+                return pFoundNode;
+            }
+        }
+    }
+    return nullptr;
+}
+
 bool TreeNode::IsExpand() const
 {
     return m_bExpand;

--- a/duilib/Control/TreeView.cpp
+++ b/duilib/Control/TreeView.cpp
@@ -480,8 +480,7 @@ bool TreeNode::AddChildNodeAt(TreeNode* pTreeNode, const size_t iIndex)
 void TreeNode::SetBkIcon(HICON hIcon, uint32_t nIconSize, bool bNeedDpiScale)
 {
     if (hIcon == nullptr) {
-        SetBkImage(_T(""));
-        AdjustIconPadding();
+        ClearBkIcon();
         return;
     }
     uint32_t nIconID = GlobalManager::Instance().Icon().AddIcon(hIcon);
@@ -494,8 +493,7 @@ void TreeNode::SetBkIconID(uint32_t nIconID, uint32_t nIconSize, bool bNeedDpiSc
     IconManager& iconManager = GlobalManager::Instance().Icon();
     DString iconString = iconManager.GetIconString(nIconID);
     if (iconString.empty()) {
-        SetBkImage(_T(""));
-        AdjustIconPadding();
+        ClearBkIcon();
         return;
     }
 
@@ -535,9 +533,8 @@ void TreeNode::SetBkIconID(uint32_t nIconID, uint32_t nIconSize, bool bNeedDpiSc
         return;
     }
     if (!oldIconString.empty()) {
-        //旧图标存在，并且图标大小不同，首先清除原来的图标
-        SetBkImage(_T(""));
-        AdjustIconPadding();
+        //旧图标存在，首先隐藏原来的图标
+        ClearBkIcon();
     }
 
     SetBkImage(iconString);
@@ -547,6 +544,14 @@ void TreeNode::SetBkIconID(uint32_t nIconID, uint32_t nIconSize, bool bNeedDpiSc
     if (m_pTreeView != nullptr) {
         SetEnableIcon(m_pTreeView->IsEnableIcon());
     }
+}
+
+void TreeNode::ClearBkIcon()
+{
+    SetBkImage(_T(""));
+    m_expandIconPadding = 0;
+    m_checkBoxIconPadding = 0;
+    AdjustIconPadding();
 }
 
 void TreeNode::SetExpandImageClass(const DString& expandClass)

--- a/duilib/Control/TreeView.cpp
+++ b/duilib/Control/TreeView.cpp
@@ -444,7 +444,7 @@ bool TreeNode::AddChildNodeAt(TreeNode* pTreeNode, const size_t iIndex)
     pTreeNode->SetEnableIcon(m_pTreeView->IsEnableIcon());
 
     //添加到ListBox容器中
-    size_t nInsertIndex = GetDescendantNodeMaxListBoxIndex();
+    size_t nInsertIndex = GetDescendantNodeMaxListBoxIndex(iIndex);
     if (!Box::IsValidItemIndex(nInsertIndex)) {
         //第一个节点
         nInsertIndex = 0;
@@ -1000,7 +1000,7 @@ size_t TreeNode::GetChildNodeCount() const
     return m_aTreeNodes.size();
 }
 
-size_t TreeNode::GetDescendantNodeMaxListBoxIndex() const
+size_t TreeNode::GetDescendantNodeMaxListBoxIndex(size_t nInsertIndex) const
 {
     size_t maxListBoxIndex = GetListBoxIndex();
     if (!Box::IsValidItemIndex(maxListBoxIndex)) {
@@ -1009,9 +1009,13 @@ size_t TreeNode::GetDescendantNodeMaxListBoxIndex() const
         }
         maxListBoxIndex = 0;
     }
-    for (TreeNode* pTreeNode : m_aTreeNodes) {
+    for (size_t nIndex = 0; nIndex < nInsertIndex; ++nIndex) {
+        if (nIndex >= m_aTreeNodes.size()) {
+            break;
+        }
+        TreeNode* pTreeNode = m_aTreeNodes[nIndex];
         if (pTreeNode != nullptr) {
-            maxListBoxIndex = std::max(pTreeNode->GetDescendantNodeMaxListBoxIndex(), maxListBoxIndex);
+            maxListBoxIndex = std::max(pTreeNode->GetDescendantNodeMaxListBoxIndex(Box::InvalidIndex), maxListBoxIndex);
         }
     }
     return maxListBoxIndex;

--- a/duilib/Control/TreeView.h
+++ b/duilib/Control/TreeView.h
@@ -181,6 +181,10 @@ public:
      */
     void SetBkIconID(uint32_t nIconID, uint32_t nIconSize, bool bNeedDpiScale);
 
+    /** 清除节点的图标，不显示节点图标
+    */
+    void ClearBkIcon();
+
     /** 设置是否显示图标
     */
     void SetEnableIcon(bool bEnable);

--- a/duilib/Control/TreeView.h
+++ b/duilib/Control/TreeView.h
@@ -120,10 +120,24 @@ public:
      */
     size_t GetChildNodeIndex(TreeNode* pTreeNode) const;
 
-    /** 获取子节点列表
+    /** 获取子节点列表（只获取一级子节点，不递归获取孙节点）
     * @param [out] childNodes 返回当前树节点的所有子节点列表
     */
     void GetChildNodes(std::vector<TreeNode*>& childNodes) const;
+
+    /** 根据子节点的控件名称(Name)，查找子节点
+    * @param [in] name 被查找的子节点的控件名称（即Control::GetName()的值）
+    * @param [in] bRecursive true表示递归查找，false表示不递归查找，只在当前节点的一级子节点查找
+    * @return 返回匹配的树节点指针，如果名称有重复的，只返回第一个
+    */
+    TreeNode* FindChildNodeByName(const DString& name, bool bRecursive) const;
+
+    /** 根据子节点的显示文本(Text)，查找子节点
+    * @param [in] name 被查找的子节点的显示文本（即LabelTemplate::GetText()的值）
+    * @return 返回匹配的树节点指针，如果显示文本有重复的，只返回第一个
+    * @param [in] bRecursive true表示递归查找，false表示不递归查找，只在当前节点的一级子节点查找
+    */
+    TreeNode* FindChildNodeByText(const DString& text, bool bRecursive) const;
 
     /** 判断是否展开状态
      * @return 返回 true 为展开状态，否则为 false

--- a/duilib/Control/TreeView.h
+++ b/duilib/Control/TreeView.h
@@ -295,9 +295,10 @@ private:
     int32_t GetExpandImagePadding(void) const;
 
     /** 获取包含自己、自己的子孙节点中，ListBox索引号最大值，用于计算新添加节点的插入位置
-    *   如果没有有效元素，则返回 Box::InvalidIndex
-    */
-    size_t GetDescendantNodeMaxListBoxIndex() const;
+     * @param [in] nInsertIndex 新的节点插入位置, 如果为Box::InvalidIndex，表示插入在最后
+     *   如果没有有效元素，则返回 Box::InvalidIndex
+     */
+    size_t GetDescendantNodeMaxListBoxIndex(size_t nInsertIndex) const;
 
     /** 设置[展开/收起]按钮后面的间隔
     */

--- a/examples/controls/ControlForm.cpp
+++ b/examples/controls/ControlForm.cpp
@@ -31,7 +31,7 @@ void ControlForm::OnInitWindow()
 {
 #ifdef DUILIB_BUILD_FOR_SDL
     //显示SDL的基本信息
-    ui::Label* pTitle = static_cast<ui::Label*>(FindControl(_T("window_title")));
+    ui::Label* pTitle = dynamic_cast<ui::Label*>(FindControl(_T("window_title")));
     if (pTitle != nullptr) {
         DString title = pTitle->GetText();
         DString driverName = GetVideoDriverName();
@@ -41,14 +41,8 @@ void ControlForm::OnInitWindow()
     }
 #endif
 
-    /**
-     * 为了让代码看起来相对容易理解，不需要频繁跟进才能看明白示例代码
-     * 我们将一些控件储存为局部变量，正确的使用应该是将他们作为成员变量
-     * 不要在每次使用的时候都需要 FindControl，否则会影响性能代码不易读
-     */
-
     /* Initialize ListBox data */
-    ui::ListBox* list = static_cast<ui::ListBox*>(FindControl(_T("list")));
+    ui::ListBox* list = dynamic_cast<ui::ListBox*>(FindControl(_T("list")));
     if (list != nullptr) {
         for (auto i = 0; i < 30; i++)
         {
@@ -60,8 +54,34 @@ void ControlForm::OnInitWindow()
         }
     }
 
+    ui::TreeView* pTree = dynamic_cast<ui::TreeView*>(FindControl(_T("tree")));
+    if (pTree != nullptr) {
+        ui::TreeNode* pRootNode = pTree->GetRootNode();
+        ASSERT(pRootNode != nullptr);
+        if (pRootNode != nullptr) {
+            ui::TreeNode* pTestNode = pRootNode->FindChildNodeByText(_T("ui::TreeView Parent Node 2"), true);
+            ASSERT(pTestNode != nullptr);
+            if (pTestNode != nullptr) {
+                ui::TreeNode* pNode0 = new ui::TreeNode(this);
+                pNode0->SetClass(_T("tree_node"));
+                pNode0->SetText(_T("Dynamic Node 0(top)"));
+                pTestNode->AddChildNodeAt(pNode0, 0);
+
+                ui::TreeNode* pNode2 = new ui::TreeNode(this);
+                pNode2->SetClass(_T("tree_node"));
+                pNode2->SetText(_T("Dynamic Node 1(end)"));
+                pTestNode->AddChildNode(pNode2);
+
+                ui::TreeNode* pNode1 = new ui::TreeNode(this);
+                pNode1->SetClass(_T("tree_node"));
+                pNode1->SetText(_T("Dynamic Node 2(at index 2)"));
+                pTestNode->AddChildNodeAt(pNode1, 2);
+            }
+        }
+    }
+
     //初始化Combo的数据
-    ui::Combo* combo = static_cast<ui::Combo*>(FindControl(_T("combo")));
+    ui::Combo* combo = dynamic_cast<ui::Combo*>(FindControl(_T("combo")));
     if (combo != nullptr) {
         ui::TreeView* pTreeView = combo->GetTreeView();
         ui::TreeNode* pTreeNode = pTreeView->GetRootNode();
@@ -95,14 +115,14 @@ void ControlForm::OnInitWindow()
 //    ASSERT(combo->GetText() == _T("Test"));
 //#endif
 
-    ui::FilterCombo* filterCombo = static_cast<ui::FilterCombo*>(FindControl(_T("filter_combo")));
+    ui::FilterCombo* filterCombo = dynamic_cast<ui::FilterCombo*>(FindControl(_T("filter_combo")));
     if (filterCombo != nullptr) {
         for (auto i = 0; i < 100; i++) {
             filterCombo->AddTextItem(ui::StringUtil::Printf(_T("Item %d FilterCombo"), i));
         }
     }
 
-    ui::CheckCombo* check_combo = static_cast<ui::CheckCombo*>(FindControl(_T("check_combo")));
+    ui::CheckCombo* check_combo = dynamic_cast<ui::CheckCombo*>(FindControl(_T("check_combo")));
     if (check_combo != nullptr) {
         check_combo->AddTextItem(_T("星期一"));
         check_combo->AddTextItem(_T("星期二"));
@@ -131,7 +151,7 @@ void ControlForm::OnInitWindow()
         300);
 
     /* Show settings menu */
-    ui::Button* settings = static_cast<ui::Button*>(FindControl(_T("settings")));
+    ui::Button* settings = dynamic_cast<ui::Button*>(FindControl(_T("settings")));
     if (settings != nullptr) {
         settings->AttachClick([this, settings](const ui::EventArgs& args) {
             ui::UiRect rect = args.GetSender()->GetPos();


### PR DESCRIPTION
功能优化：ui::TreeNode 无法使用FindSubControl(子节点Name) 来查找子节点 #365
修复缺陷：TreeNode::AddChildNodeAt(pNode, index) 在视觉上并没有插入到指定位置 #367
修复缺陷：TreeNode::SetBkIcon 重新设置图标时，图标位置前移了 #364