### PR TITLE
新增 Claude Code AI 辅助开发集成

### DIFF
--- a/.claude/docs/nim-duilib-llm-reference.md
+++ b/.claude/docs/nim-duilib-llm-reference.md
@@ -1,0 +1,564 @@
+# nim_duilib LLM 快速参考
+
+> 本文档专为 LLM/AI 代理优化，提供 nim_duilib 的核心 API 速查。
+
+## 一、XML 布局结构
+
+### 窗口模板
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Window size="800,600" min_size="80,60"
+        caption="0,0,0,36" use_system_caption="false"
+        snap_layout_menu="true" sys_menu="true" sys_menu_rect="0,0,36,36"
+        shadow_type="default" shadow_attached="true"
+        layered_window="true" alpha="255" size_box="4,4,4,4"
+        icon="../public/caption/logo.ico">
+  <VBox bkcolor="bk_wnd_darkcolor">
+    <!-- 标题栏 -->
+    <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
+      <Control />
+      <Button class="btn_wnd_min_11" name="minbtn" height="32" width="40" margin="0,2,0,2"/>
+      <Box height="stretch" width="40" margin="0,2,0,2">
+        <Button class="btn_wnd_max_11" name="maxbtn" height="32" width="stretch"/>
+        <Button class="btn_wnd_restore_11" name="restorebtn" height="32" width="stretch" visible="false"/>
+      </Box>
+      <Button class="btn_wnd_close_11" name="closebtn" height="stretch" width="40"/>
+    </HBox>
+    <!-- 内容区域 -->
+    <Box>
+      <!-- 放置你的内容 -->
+    </Box>
+  </VBox>
+</Window>
+```
+
+### Window 属性速查
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| size | size | 窗口初始大小，支持百分比 "75%,75%" |
+| min_size / max_size | size | 最小/最大尺寸 |
+| caption | rect | 标题栏可拖动区域 "0,0,0,36" |
+| size_box | rect | 可拖动调整大小的边距 "4,4,4,4" |
+| shadow_type | string | 阴影类型: default/big/big_round/small/small_round/menu/menu_round/none/none_round |
+| shadow_attached | bool | 是否附加阴影 |
+| layered_window | bool | 是否为层窗口 |
+| alpha | int | 透明度 0-255 |
+| round_corner | size | 窗口圆角 "4,4" |
+| icon | string | 窗口图标路径(ico) |
+| use_system_caption | bool | 使用系统标题栏 |
+| text / textid | string | 窗口标题/多语言ID |
+
+## 二、容器类型速查
+
+| XML节点 | 布局方式 | 说明 |
+|---------|---------|------|
+| Box | 浮动(Layout) | 自由定位，子控件绝对或相对布局 |
+| VBox | 垂直(VLayout) | 子控件从上到下依次排列 |
+| HBox | 水平(HLayout) | 子控件从左到右依次排列 |
+| VFlowBox | 垂直流式 | 垂直排列，自动换列 |
+| HFlowBox | 水平流式 | 水平排列，自动换行 |
+| VTileBox | 垂直瓦片 | 网格式垂直排列，columns属性 |
+| HTileBox | 水平瓦片 | 网格式水平排列，rows属性 |
+| GridBox | 网格(GridLayout) | 网格布局，支持单元格合并 |
+| TabBox | 浮动 | 多页签切换，仅显示当前页 |
+| ScrollBox | 浮动+滚动条 | 可滚动的Box |
+| VScrollBox | 垂直+滚动条 | 可滚动的VBox |
+| HScrollBox | 水平+滚动条 | 可滚动的HBox |
+| VListBox | 垂直列表 | 可选择的垂直列表 |
+| HListBox | 水平列表 | 可选择的水平列表 |
+| VirtualVListBox | 虚拟垂直列表 | 大数据量虚拟列表(垂直) |
+| VirtualHListBox | 虚拟水平列表 | 大数据量虚拟列表(水平) |
+
+### 容器属性
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| child_margin | int | 子控件间距(XY相同) |
+| child_margin_x | int | 子控件水平间距 |
+| child_margin_y | int | 子控件垂直间距 |
+| child_halign | string | 子控件水平对齐: left/center/right |
+| child_valign | string | 子控件垂直对齐: top/center/bottom |
+| mouse_child | bool | 子控件是否响应鼠标 |
+| padding | rect | 内边距 "L,T,R,B" |
+
+## 三、控件类型速查
+
+| XML节点 | 基类 | 说明 |
+|---------|------|------|
+| Control | - | 基础控件/占位符 |
+| Label | Control | 文本标签 |
+| Button | Label | 按钮 |
+| CheckBox | Button | 复选框 |
+| Option | CheckBox | 单选按钮(group属性分组) |
+| Combo | Box | 下拉组合框 |
+| FilterCombo | Combo | 可过滤的下拉框 |
+| CheckCombo | Box | 多选下拉框 |
+| ComboButton | Box | 带下拉的按钮 |
+| RichEdit | ScrollBox | 文本编辑框(单行/多行/密码) |
+| RichText | Control | 富文本显示(HTML子集) |
+| Progress | Label | 进度条 |
+| Slider | Progress | 滑块 |
+| CircleProgress | Progress | 圆形进度条 |
+| DateTime | Label | 日期时间选择器 |
+| TreeView | VListBox | 树形控件 |
+| TreeNode | Box | 树节点 |
+| ListCtrl | VBox | 列表控件(Report/List/Icon视图) |
+| PropertyGrid | VListBox | 属性网格 |
+| HyperLink | Label | 超级链接 |
+| Line | Control | 画线控件 |
+| Split / SplitBox | Control/Box | 分隔条 |
+| ScrollBar | Control | 滚动条 |
+| TabCtrl | HBox | 标签页控件 |
+| IPAddress | HBox | IP地址输入 |
+| HotKey | HBox | 热键输入 |
+| GroupBox/GroupVBox/GroupHBox | Box | 分组容器 |
+| ColorControl/ColorPicker* | - | 颜色选择器组件 |
+| DirectoryTree | TreeView | 目录树 |
+
+### Control 通用属性(所有控件继承)
+| 属性 | 默认值 | 类型 | 说明 |
+|------|--------|------|------|
+| name | | string | 控件名称(窗口内建议唯一) |
+| class | | string | 引用global.xml中的通用样式 |
+| width | stretch | int/string | 宽度: 数值/stretch/auto/"50%" |
+| height | stretch | int/string | 高度: 数值/stretch/auto/"50%" |
+| min_width / min_height | -1 | int | 最小宽度/高度 |
+| max_width / max_height | MAX | int/string | 最大宽度/高度 |
+| margin | 0,0,0,0 | rect | 外边距 "L,T,R,B" |
+| padding | 0,0,0,0 | rect | 内边距 "L,T,R,B" |
+| halign | left | string | 水平对齐: left/center/right |
+| valign | top | string | 垂直对齐: top/center/bottom |
+| visible | true | bool | 是否可见 |
+| enabled | true | bool | 是否可用 |
+| float | false | bool | 是否绝对定位 |
+| bkcolor | | string | 背景色(颜色名/ARGB) |
+| bkimage | | string | 背景图片 |
+| normal_image / hot_image / pushed_image / disabled_image | | string | 各状态图片 |
+| normal_color / hot_color / pushed_color / disabled_color | | string | 各状态颜色 |
+| border_size | 0 | int/rect | 边框大小 |
+| border_color | | string | 边框颜色 |
+| border_round | 0,0 | size | 边框圆角 |
+| tooltip_text | | string | 鼠标悬浮提示 |
+| alpha | 255 | int | 透明度 0-255 |
+| cursor_type | arrow | string | 光标: arrow/hand/ibeam/wait/cross/size_we/size_ns 等 |
+| no_focus | false | bool | 是否不可获取焦点 |
+| tab_stop | true | bool | 是否允许TAB切换 |
+| fade_visible | true | bool | 可见性变化时是否有动画 |
+| box_shadow | | string | 阴影 "color='red' offset='0,0' blurradius='8' spreadradius='8'" |
+
+### Label 属性(继承 Control)
+| 属性 | 默认值 | 类型 | 说明 |
+|------|--------|------|------|
+| text | | string | 显示文本 |
+| text_id | | string | 多语言ID |
+| text_align | "left,top" | string | 对齐: left/hcenter/right/hjustify + top/vcenter/bottom |
+| text_padding | 0,0,0,0 | rect | 文字内边距 |
+| font | | string | 字体ID(定义在global.xml) |
+| normal_text_color | | string | 普通文字颜色 |
+| hot_text_color | | string | 悬浮文字颜色 |
+| single_line | true | bool | 单行显示 |
+| multi_line | false | bool | 多行显示 |
+| end_ellipsis | false | bool | 省略号截断 |
+| rich_text | false | bool | 支持HTML子集富文本 |
+
+### CheckBox 额外属性(继承 Button)
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| selected | bool | 是否选中 |
+| selected_normal_image / selected_hot_image / ... | string | 选中状态各状态图片 |
+
+### Option 额外属性(继承 CheckBox)
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| group | string | 分组名称，同组内互斥 |
+
+### RichEdit 属性(继承 ScrollBox)
+| 属性 | 默认值 | 类型 | 说明 |
+|------|--------|------|------|
+| text | | string | 文本内容 |
+| font | | string | 字体ID |
+| text_align | "left,top" | string | 对齐方式 |
+| text_padding | | rect | 文字内边距 |
+| single_line | true | bool | 单行模式 |
+| multi_line | false | bool | 多行模式 |
+| password | false | bool | 密码模式 |
+| readonly | false | bool | 只读 |
+| number_only | false | bool | 仅数字 |
+| max_number / min_number | | int | 数字范围 |
+| limit_text | | int | 最大字符数 |
+| prompt_text | | string | 占位提示文字 |
+| prompt_color | | string | 提示文字颜色 |
+| word_wrap | false | bool | 自动换行 |
+| vscrollbar / hscrollbar | false | bool | 滚动条 |
+| want_return | false | bool | 接受回车 |
+| want_tab | false | bool | 接受Tab |
+| caret_color | | string | 光标颜色 |
+| normal_text_color | | string | 文字颜色 |
+
+### Progress 属性(继承 Label)
+| 属性 | 默认值 | 类型 | 说明 |
+|------|--------|------|------|
+| min | 0 | int | 最小值 |
+| max | 100 | int | 最大值 |
+| value | 0 | int | 当前值 |
+| horizontal | true | bool | 水平方向 |
+| progress_color | | string | 进度条颜色 |
+| progress_image | | string | 进度条图片 |
+
+### Combo 属性(继承 Box)
+| 属性 | 默认值 | 类型 | 说明 |
+|------|--------|------|------|
+| combo_type | "drop_down" | string | "drop_down"(可编辑) / "drop_list"(不可编辑) |
+| dropbox_size | | string | 下拉列表尺寸 |
+| popup_top | false | bool | 向上弹出 |
+
+## 四、全局资源 (global.xml)
+
+### 字体定义
+```xml
+<DefaultFontFamilyNames value="微软雅黑,宋体"/>
+<Font id="system_12" name="system" size="12"/>
+<Font id="system_bold_14" name="system" size="14" bold="true"/>
+<FontFile file="RobotoMono-Regular.ttf" desc="Roboto Mono常规"/>
+```
+
+### 颜色定义
+```xml
+<TextColor name="default_font_color" value="#FF333333"/>
+<TextColor name="bk_wnd_darkcolor" value="#FF2B2B2B"/>
+```
+颜色格式: "#AARRGGBB"(ARGB) 或 "#RRGGBB"(RGB) 或颜色名(Blue/Red/White...)
+
+### 通用样式(Class)
+```xml
+<Class name="btn_default" font="system_12" normal_text_color="white"
+       normal_image="file='btn_normal.png'"
+       hot_image="file='btn_hot.png'"
+       pushed_image="file='btn_pushed.png'"/>
+```
+使用: `<Button class="btn_default" text="Click"/>`
+**class属性必须写在所有属性最前面**
+
+## 五、图片属性
+```xml
+<!-- 简单用法 -->
+<Control bkimage="logo.png"/>
+
+<!-- 完整属性 -->
+<Control bkimage="file='icon.svg' width='24' height='24' valign='center' halign='center'"/>
+```
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| file | string | 图片路径(相对于主题目录) |
+| width / height | string | 图片尺寸(像素或百分比) |
+| src | rect | 源区域裁剪 "L,T,R,B" |
+| dest | rect | 目标绘制区域 |
+| corner | rect | 九宫格参数 "L,T,R,B" |
+| fade | int | 透明度 0-255 |
+| halign / valign | string | 对齐方式 |
+| xtiled / ytiled | bool | 平铺绘制 |
+| auto_play | bool | 动画自动播放 |
+| play_count | int | 动画播放次数(-1无限) |
+
+支持格式: PNG, SVG, JPG, GIF, BMP, APNG, WEBP, ICO, Lottie-JSON, PAG
+
+## 六、XML 事件系统
+
+### XML内联事件
+```xml
+<Button name="my_btn" text="Click">
+  <Event type="click" receiver="target_control_name" apply_attribute="visible='true'"/>
+</Button>
+
+<!-- 事件目标类型 -->
+<!-- receiver="name"           按名称查找控件 -->
+<!-- receiver="./name"         在当前容器内查找 -->
+<!-- receiver=""               控件自身 -->
+<!-- receiver="#window#"       窗口 -->
+```
+
+### 常用事件类型
+| type值 | 说明 |
+|--------|------|
+| click | 点击 |
+| rclick | 右键点击 |
+| mouse_enter / mouse_leave | 鼠标进入/离开 |
+| mouse_button_down / mouse_button_up | 鼠标按下/释放 |
+| mouse_double_click | 双击 |
+| select / unselect | 选中/取消选中(ListBox/Combo) |
+| check / uncheck | 勾选/取消勾选(CheckBox) |
+| tab_select | 标签页切换 |
+| text_changed | 文本变化 |
+| value_changed | 值变化 |
+| key_down / key_up | 按键 |
+| return | 回车 |
+| visible_changed | 可见性变化 |
+| window_close | 窗口关闭 |
+| window_size | 窗口大小变化 |
+
+## 七、C++ 代码模式
+
+### 窗口类模板
+```cpp
+// MyForm.h
+#ifndef MY_FORM_H_
+#define MY_FORM_H_
+#include "duilib/duilib.h"
+
+class MyForm : public ui::WindowImplBase
+{
+    typedef ui::WindowImplBase BaseClass;
+public:
+    MyForm();
+    virtual ~MyForm() override;
+    virtual DString GetSkinFolder() override;
+    virtual DString GetSkinFile() override;
+    virtual void OnInitWindow() override;
+};
+#endif
+
+// MyForm.cpp
+#include "MyForm.h"
+
+MyForm::MyForm() {}
+MyForm::~MyForm() {}
+
+DString MyForm::GetSkinFolder() { return _T("my_skin"); }
+DString MyForm::GetSkinFile() { return _T("my_form.xml"); }
+
+void MyForm::OnInitWindow()
+{
+    BaseClass::OnInitWindow();
+    // 在这里初始化控件和绑定事件
+}
+```
+
+### 主线程模板
+```cpp
+// MainThread.h
+#include "duilib/duilib.h"
+class MainThread : public ui::FrameworkThread
+{
+public:
+    MainThread();
+    virtual ~MainThread() override;
+private:
+    virtual void OnInit() override;
+    virtual void OnCleanup() override;
+};
+
+// MainThread.cpp
+#include "MainThread.h"
+#include "MyForm.h"
+
+MainThread::MainThread() : FrameworkThread(_T("MainThread"), ui::kThreadUI) {}
+MainThread::~MainThread() {}
+
+void MainThread::OnInit()
+{
+    ui::FilePath resourcePath = ui::FilePathUtil::GetCurrentModuleDirectory();
+    resourcePath += _T("resources\\");
+    ui::GlobalManager::Instance().Startup(ui::LocalFilesResParam(resourcePath));
+
+    MyForm* window = new MyForm();
+    window->CreateWnd(nullptr, ui::WindowCreateParam(_T("MyApp"), true));
+    window->PostQuitMsgWhenClosed(true);
+    window->ShowWindow(ui::kSW_SHOW_NORMAL);
+}
+
+void MainThread::OnCleanup()
+{
+    ui::GlobalManager::Instance().Shutdown();
+}
+```
+
+### 入口函数(Windows)
+```cpp
+#include "MainThread.h"
+int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR, int)
+{
+    MainThread thread;
+    thread.RunMessageLoop();
+    return 0;
+}
+```
+
+### 控件操作
+```cpp
+// 查找控件
+ui::Button* btn = dynamic_cast<ui::Button*>(FindControl(_T("my_button")));
+ui::Label* label = dynamic_cast<ui::Label*>(FindControl(_T("my_label")));
+ui::RichEdit* edit = dynamic_cast<ui::RichEdit*>(FindControl(_T("my_edit")));
+ui::CheckBox* check = dynamic_cast<ui::CheckBox*>(FindControl(_T("my_check")));
+ui::Combo* combo = dynamic_cast<ui::Combo*>(FindControl(_T("my_combo")));
+ui::ListBox* list = dynamic_cast<ui::ListBox*>(FindControl(_T("my_list")));
+ui::Progress* progress = dynamic_cast<ui::Progress*>(FindControl(_T("my_progress")));
+
+// 设置属性
+label->SetText(_T("Hello"));
+edit->SetText(_T("Input"));
+DString text = edit->GetText();
+check->SetSelected(true);
+bool isChecked = check->IsSelected();
+progress->SetValue(50);
+
+// 可见性
+btn->SetVisible(true);
+btn->SetEnabled(false);
+```
+
+### 事件绑定
+```cpp
+void MyForm::OnInitWindow()
+{
+    BaseClass::OnInitWindow();
+
+    // 按钮点击
+    ui::Button* btn = dynamic_cast<ui::Button*>(FindControl(_T("btn_ok")));
+    if (btn) {
+        btn->AttachClick([this](const ui::EventArgs& args) {
+            // 处理逻辑
+            return true;
+        });
+    }
+
+    // 复选框状态变化
+    ui::CheckBox* check = dynamic_cast<ui::CheckBox*>(FindControl(_T("my_check")));
+    if (check) {
+        check->AttachSelect([this](const ui::EventArgs& args) {
+            // 选中
+            return true;
+        });
+        check->AttachUnSelect([this](const ui::EventArgs& args) {
+            // 取消选中
+            return true;
+        });
+    }
+
+    // 文本变化
+    ui::RichEdit* edit = dynamic_cast<ui::RichEdit*>(FindControl(_T("my_edit")));
+    if (edit) {
+        edit->AttachTextChange([this](const ui::EventArgs& args) {
+            // 文字改变
+            return true;
+        });
+    }
+
+    // 列表选择
+    ui::ListBox* list = dynamic_cast<ui::ListBox*>(FindControl(_T("my_list")));
+    if (list) {
+        list->AttachSelect([this](const ui::EventArgs& args) {
+            size_t newIndex = args.wParam;
+            size_t oldIndex = args.lParam;
+            return true;
+        });
+    }
+
+    // 通用事件绑定
+    btn->AttachEvent(ui::kEventMouseEnter, [](const ui::EventArgs&) {
+        return true;
+    });
+}
+```
+
+### ListBox 动态添加项
+```cpp
+ui::ListBox* list = dynamic_cast<ui::ListBox*>(FindControl(_T("my_list")));
+for (int i = 0; i < 100; i++) {
+    ui::ListBoxItem* item = new ui::ListBoxItem(this);
+    item->SetText(ui::StringUtil::Printf(_T("Item %d"), i));
+    item->SetClass(_T("listitem"));
+    item->SetFixedHeight(ui::UiFixedInt(20), true, true);
+    list->AddItem(item);
+}
+```
+
+### TreeView 动态添加节点
+```cpp
+ui::TreeView* tree = dynamic_cast<ui::TreeView*>(FindControl(_T("my_tree")));
+ui::TreeNode* root = tree->GetRootNode();
+ui::TreeNode* node = new ui::TreeNode(this);
+node->SetClass(_T("tree_node"));
+node->SetText(_T("New Node"));
+root->AddChildNode(node);
+```
+
+### Combo 动态添加选项
+```cpp
+ui::Combo* combo = dynamic_cast<ui::Combo*>(FindControl(_T("my_combo")));
+ui::TreeView* treeView = combo->GetTreeView();
+ui::TreeNode* treeNode = treeView->GetRootNode();
+for (int i = 0; i < 10; i++) {
+    ui::TreeNode* node = new ui::TreeNode(this);
+    node->SetClass(_T("tree_node"));
+    node->SetText(ui::StringUtil::Printf(_T("Option %d"), i));
+    treeNode->AddChildNode(node);
+}
+combo->SetCurSel(0); // 默认选中第一项
+```
+
+### 线程间通信
+```cpp
+// 投递任务到工作线程
+ui::GlobalManager::Instance().Thread().PostTask(ui::kThreadWorker,
+    UiBind(&MyForm::DoBackgroundWork, this));
+
+// 投递任务到UI线程
+ui::GlobalManager::Instance().Thread().PostTask(ui::kThreadUI,
+    UiBind(&MyForm::UpdateUI, this));
+
+// 定时重复任务
+ui::GlobalManager::Instance().Thread().PostRepeatedTask(ui::kThreadWorker,
+    ui::UiBind(this, [this]() {
+        // 每次执行的逻辑
+    }),
+    200 // 毫秒间隔
+);
+```
+
+### 弱回调保护
+```cpp
+// 使用 UiBind 绑定成员函数(自动弱引用保护)
+UiBind(&MyForm::OnButtonClick, this);
+
+// lambda 中使用 ui::UiBind 包装
+ui::UiBind(this, [this]() {
+    // 控件销毁后不会执行
+});
+```
+
+## 八、布局属性速查
+
+### 瓦片布局 (HTileBox/VTileBox)
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| item_size | size | 子项大小 "100,40" |
+| rows (HTileBox) | int/"auto" | 行数 |
+| columns (VTileBox) | int/"auto" | 列数 |
+| scale_down | bool | 超出时缩小 |
+
+### 网格布局 (GridBox)
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| rows | int | 网格行数(0自动) |
+| columns | int | 网格列数(0自动) |
+| grid_width | int | 单元格宽度(0自动) |
+| grid_height | int | 单元格高度(0自动) |
+子控件使用 `row_span`/`col_span` 属性合并单元格。
+
+### ScrollBox 额外属性
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| vscrollbar | bool | 垂直滚动条 |
+| hscrollbar | bool | 水平滚动条 |
+| vscrollbar_class | string | 垂直滚动条样式 |
+| hscrollbar_class | string | 水平滚动条样式 |
+
+## 九、文件路径约定
+- 主题资源根目录: `bin/resources/themes/default/`
+- 全局配置: `bin/resources/themes/default/global.xml`
+- 窗口XML: `bin/resources/themes/default/<skin_folder>/<skin_file>.xml`
+- 公共图片: `bin/resources/themes/default/public/`
+- 字体文件: `bin/resources/fonts/`
+- 语言文件: `bin/resources/themes/default/lang/` (zh_CN.txt, en_US.txt)
+- 示例源码: `examples/<example_name>/`

--- a/.claude/register.bat
+++ b/.claude/register.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+chcp 65001 >nul 2>&1
+REM nim_duilib AI toolchain - global register script (Windows)
+REM Usage: cd nim_duilib && .claude\register.bat
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0register.ps1"
+endlocal

--- a/.claude/register.ps1
+++ b/.claude/register.ps1
@@ -1,0 +1,136 @@
+# nim_duilib AI toolchain - global register script
+# Usage: cd nim_duilib && .claude\register.bat
+#    or: pwsh .claude\register.ps1
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$DuilibRoot = (Resolve-Path (Join-Path $ScriptDir "..")).Path
+$ClaudeHome = Join-Path $env:USERPROFILE ".claude"
+$GlobalSkillsDir = Join-Path $ClaudeHome "skills"
+$NimInitDir = Join-Path $GlobalSkillsDir "nim-init"
+
+Write-Host "=== nim_duilib AI toolchain register ===" -ForegroundColor Cyan
+Write-Host "nim_duilib path: $DuilibRoot"
+Write-Host ""
+
+# Validate
+if (-not (Test-Path (Join-Path (Join-Path $DuilibRoot "duilib") "duilib.h"))) {
+    Write-Host "Error: nim_duilib project not detected. Run this from nim_duilib root." -ForegroundColor Red
+    exit 1
+}
+
+# Normalize path for use in markdown (forward slashes)
+$DuilibRootUnix = $DuilibRoot -replace '\\', '/'
+
+# ============================================================
+# Step 1: Register all nim-duilib-* skills as global skills
+# ============================================================
+Write-Host "[1/2] Registering global skills..." -ForegroundColor Yellow
+
+$SourceSkillsDir = Join-Path $ScriptDir "skills"
+$SkillFiles = Get-ChildItem -Path $SourceSkillsDir -Filter "nim-duilib-*.md" -File
+
+foreach ($file in $SkillFiles) {
+    # Each skill needs its own subdirectory: ~/.claude/skills/<name>/SKILL.md
+    $skillName = $file.BaseName  # e.g. "nim-duilib-create-window"
+    $targetDir = Join-Path $GlobalSkillsDir $skillName
+    if (-not (Test-Path $targetDir)) {
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    }
+    Copy-Item -Path $file.FullName -Destination (Join-Path $targetDir "SKILL.md") -Force
+    Write-Host "  + $skillName"
+}
+
+# ============================================================
+# Step 2: Register /nim-init command
+# ============================================================
+Write-Host "[2/2] Registering /nim-init command..." -ForegroundColor Yellow
+
+if (-not (Test-Path $NimInitDir)) {
+    New-Item -ItemType Directory -Path $NimInitDir -Force | Out-Null
+}
+
+$SkillContent = @"
+---
+name: nim-init
+description: "Initialize nim_duilib AI dev toolkit for current project (copy LLM docs + update CLAUDE.md). Global skills are already available - this command sets up project-specific config."
+user-invocable: true
+disable-model-invocation: true
+---
+
+# nim_duilib AI Toolkit - Project Init
+
+When the user invokes /nim-init, follow these steps:
+
+## Config
+- nim_duilib install path: ``$DuilibRootUnix``
+- Source docs: ``$DuilibRootUnix/.claude/docs/``
+
+## Step 1: Copy LLM reference doc
+Run this bash command to copy the reference doc to the current project:
+``````bash
+mkdir -p .claude/docs
+cp "$DuilibRootUnix/.claude/docs/nim-duilib-llm-reference.md" .claude/docs/
+``````
+
+## Step 2: Update CLAUDE.md
+Check if the current project's CLAUDE.md already contains "nim_duilib UI". If not, append the following block (create CLAUDE.md if it doesn't exist):
+
+``````markdown
+
+## nim_duilib UI
+
+This project uses [nim_duilib](https://github.com/rhett-lee/nim_duilib) as the UI framework.
+Library path: ``$DuilibRootUnix``
+
+- LLM reference: ``.claude/docs/nim-duilib-llm-reference.md``
+- XML layouts: ``bin/resources/themes/default/<skin_folder>/``
+- Global resources (fonts/colors/styles): ``bin/resources/themes/default/global.xml``
+- nim_duilib docs: ``$DuilibRootUnix/docs/``
+- nim_duilib examples: ``$DuilibRootUnix/examples/``
+
+### Resource rules (IMPORTANT)
+- MUST copy: ``global.xml`` + ``public/`` (shared icons) + your app's own skin directory
+- NEVER copy demo directories (basic/, controls/, layout/, chat/, cef/, render/, etc.)
+- NEVER copy bin/*.exe, bin/*.dll, bin/bin.zip
+- Resource packaging: local files (dev) / ZIP file (release) / embedded EXE (Windows single-file)
+
+### Key patterns
+- Window class extends ``ui::WindowImplBase``, override ``GetSkinFolder()``/``GetSkinFile()``/``OnInitWindow()``
+- Main thread extends ``ui::FrameworkThread``, init resources and create window in ``OnInit()``
+- Find control: ``dynamic_cast<ui::Type*>(FindControl(_T("name")))``
+- Bind event: ``control->AttachClick([](const ui::EventArgs&) { return true; });``
+- String type: ``DString``, literals wrapped with ``_T("...")``
+``````
+
+## Step 3: Report
+Tell the user initialization is complete. Note that nim_duilib skills are already globally available (no per-project copy needed):
+- nim-duilib-create-window - Create new window
+- nim-duilib-xml-layout - Design XML layout
+- nim-duilib-add-control - Add controls
+- nim-duilib-event-handler - Event handlers
+- nim-duilib-theme - Theme customization
+- nim-duilib-resource-pack - Resource packaging / single EXE
+"@
+
+$SkillPath = Join-Path $NimInitDir "SKILL.md"
+[System.IO.File]::WriteAllText($SkillPath, $SkillContent, [System.Text.UTF8Encoding]::new($false))
+
+# ============================================================
+# Done
+# ============================================================
+Write-Host ""
+Write-Host "=== Register complete ===" -ForegroundColor Green
+Write-Host ""
+Write-Host "Registered:" -ForegroundColor Yellow
+Write-Host "  /nim-init               - project initialization command"
+foreach ($file in $SkillFiles) {
+    Write-Host "  /$($file.BaseName)  - global skill"
+}
+Write-Host ""
+Write-Host "Skills are now globally available in ALL projects." -ForegroundColor Cyan
+Write-Host "Run /nim-init in a project to set up CLAUDE.md and LLM docs."
+Write-Host ""
+Write-Host "To update after editing skills: just re-run this script." -ForegroundColor Gray

--- a/.claude/register.sh
+++ b/.claude/register.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# nim_duilib AI toolchain - global register script
+# Usage: cd nim_duilib && bash .claude/register.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DUILIB_ROOT="$(dirname "$SCRIPT_DIR")"
+CLAUDE_HOME="${HOME}/.claude"
+GLOBAL_SKILLS_DIR="${CLAUDE_HOME}/skills"
+
+echo "=== nim_duilib AI toolchain register ==="
+echo "nim_duilib path: ${DUILIB_ROOT}"
+echo ""
+
+# Validate
+if [ ! -f "${DUILIB_ROOT}/duilib/duilib.h" ]; then
+    echo "Error: nim_duilib project not detected. Run this from nim_duilib root."
+    exit 1
+fi
+
+# ============================================================
+# Step 1: Register all nim-duilib-* skills as global skills
+# ============================================================
+echo "[1/2] Registering global skills..."
+
+for skill_file in "${SCRIPT_DIR}/skills"/nim-duilib-*.md; do
+    [ -f "$skill_file" ] || continue
+    skill_name="$(basename "$skill_file" .md)"
+    target_dir="${GLOBAL_SKILLS_DIR}/${skill_name}"
+    mkdir -p "$target_dir"
+    cp "$skill_file" "${target_dir}/SKILL.md"
+    echo "  + ${skill_name}"
+done
+
+# ============================================================
+# Step 2: Register /nim-init command
+# ============================================================
+echo "[2/2] Registering /nim-init command..."
+
+NIM_INIT_DIR="${GLOBAL_SKILLS_DIR}/nim-init"
+mkdir -p "$NIM_INIT_DIR"
+
+cat > "${NIM_INIT_DIR}/SKILL.md" << SKILLEOF
+---
+name: nim-init
+description: "Initialize nim_duilib AI dev toolkit for current project (copy LLM docs + update CLAUDE.md). Global skills are already available - this command sets up project-specific config."
+user-invocable: true
+disable-model-invocation: true
+---
+
+# nim_duilib AI Toolkit - Project Init
+
+When the user invokes /nim-init, follow these steps:
+
+## Config
+- nim_duilib install path: \`${DUILIB_ROOT}\`
+- Source docs: \`${DUILIB_ROOT}/.claude/docs/\`
+
+## Step 1: Copy LLM reference doc
+Run this bash command to copy the reference doc to the current project:
+\`\`\`bash
+mkdir -p .claude/docs
+cp "${DUILIB_ROOT}/.claude/docs/nim-duilib-llm-reference.md" .claude/docs/
+\`\`\`
+
+## Step 2: Update CLAUDE.md
+Check if the current project's CLAUDE.md already contains "nim_duilib UI". If not, append the following block (create CLAUDE.md if it doesn't exist):
+
+\`\`\`markdown
+
+## nim_duilib UI
+
+This project uses [nim_duilib](https://github.com/rhett-lee/nim_duilib) as the UI framework.
+Library path: \`${DUILIB_ROOT}\`
+
+- LLM reference: \`.claude/docs/nim-duilib-llm-reference.md\`
+- XML layouts: \`bin/resources/themes/default/<skin_folder>/\`
+- Global resources (fonts/colors/styles): \`bin/resources/themes/default/global.xml\`
+- nim_duilib docs: \`${DUILIB_ROOT}/docs/\`
+- nim_duilib examples: \`${DUILIB_ROOT}/examples/\`
+
+### Resource rules (IMPORTANT)
+- MUST copy: \`global.xml\` + \`public/\` (shared icons) + your app's own skin directory
+- NEVER copy demo directories (basic/, controls/, layout/, chat/, cef/, render/, etc.)
+- NEVER copy bin/*.exe, bin/*.dll, bin/bin.zip
+- Resource packaging: local files (dev) / ZIP file (release) / embedded EXE (Windows single-file)
+
+### Key patterns
+- Window class extends \`ui::WindowImplBase\`, override \`GetSkinFolder()\`/\`GetSkinFile()\`/\`OnInitWindow()\`
+- Main thread extends \`ui::FrameworkThread\`, init resources and create window in \`OnInit()\`
+- Find control: \`dynamic_cast<ui::Type*>(FindControl(_T("name")))\`
+- Bind event: \`control->AttachClick([](const ui::EventArgs&) { return true; });\`
+- String type: \`DString\`, literals wrapped with \`_T("...")\`
+\`\`\`
+
+## Step 3: Report
+Tell the user initialization is complete. Note that nim_duilib skills are already globally available (no per-project copy needed):
+- nim-duilib-create-window - Create new window
+- nim-duilib-xml-layout - Design XML layout
+- nim-duilib-add-control - Add controls
+- nim-duilib-event-handler - Event handlers
+- nim-duilib-theme - Theme customization
+- nim-duilib-resource-pack - Resource packaging / single EXE
+SKILLEOF
+
+# ============================================================
+# Done
+# ============================================================
+echo ""
+echo "=== Register complete ==="
+echo ""
+echo "Registered:"
+echo "  /nim-init               - project initialization command"
+for skill_file in "${SCRIPT_DIR}/skills"/nim-duilib-*.md; do
+    [ -f "$skill_file" ] || continue
+    echo "  /$(basename "$skill_file" .md)  - global skill"
+done
+echo ""
+echo "Skills are now globally available in ALL projects."
+echo "Run /nim-init in a project to set up CLAUDE.md and LLM docs."
+echo ""
+echo "To update after editing skills: just re-run this script."

--- a/.claude/skills/nim-duilib-add-control.md
+++ b/.claude/skills/nim-duilib-add-control.md
@@ -1,0 +1,202 @@
+---
+name: nim-add-control
+description: 向 nim_duilib 界面添加控件（XML + C++ 事件绑定）
+trigger: 当用户要求添加按钮、输入框、列表、复选框等控件时触发
+---
+
+# nim_duilib 添加控件
+
+## 执行步骤
+
+### 1. 确认控件需求
+- 控件类型（按钮、输入框、列表等）
+- 放置位置（哪个XML文件、哪个容器内）
+- 是否需要 C++ 事件处理
+
+### 2. 控件 XML 速查
+
+**按钮 Button:**
+```xml
+<Button name="btn_submit" text="提交" width="80" height="32"
+        class="btn_global_blue_80x30" tooltip_text="点击提交"/>
+```
+
+**文本标签 Label:**
+```xml
+<Label name="lbl_info" text="信息文本" font="system_14"
+       normal_text_color="default_font_color" text_align="left,vcenter"/>
+```
+
+**输入框 RichEdit (单行):**
+```xml
+<RichEdit name="edit_input" width="200" height="30"
+          single_line="true" prompt_text="请输入..."
+          font="system_12" text_padding="4,2,4,2"
+          border_size="1" border_color="gray" border_round="4,4"
+          hot_border_color="blue" focus_border_color="blue"/>
+```
+
+**输入框 RichEdit (多行):**
+```xml
+<RichEdit name="edit_content" width="stretch" height="200"
+          multi_line="true" word_wrap="true" vscrollbar="true"
+          want_return="true" prompt_text="请输入内容..."
+          border_size="1" border_color="gray"/>
+```
+
+**密码输入框:**
+```xml
+<RichEdit name="edit_pwd" width="200" height="30"
+          single_line="true" password="true" prompt_text="请输入密码"
+          border_size="1" border_color="gray" border_round="4,4"/>
+```
+
+**复选框 CheckBox:**
+```xml
+<CheckBox name="chk_agree" text="我同意协议" class="checkbox_2"/>
+```
+
+**单选按钮 Option:**
+```xml
+<Option name="opt_male" text="男" group="gender" class="option_1" selected="true"/>
+<Option name="opt_female" text="女" group="gender" class="option_1"/>
+```
+
+**下拉框 Combo:**
+```xml
+<Combo name="combo_type" class="combo" width="150" height="30"/>
+```
+
+**进度条 Progress:**
+```xml
+<Progress name="prog_download" width="stretch" height="16"
+          min="0" max="100" value="0"
+          bkcolor="lightgray" progress_color="blue" border_round="8,8"/>
+```
+
+**滑块 Slider:**
+```xml
+<Slider name="slider_volume" width="200" height="20"
+        min="0" max="100" value="50" step="1"/>
+```
+
+**列表 VListBox:**
+```xml
+<VListBox name="list_items" width="stretch" height="stretch"
+          vscrollbar="true" class="list"/>
+```
+
+**树形控件 TreeView:**
+```xml
+<TreeView name="tree_files" width="stretch" height="stretch"
+          vscrollbar="true" class="tree_view"/>
+```
+
+**分隔线 Line:**
+```xml
+<Line line_color="gray" line_width="1" height="1"/>           <!-- 水平线 -->
+<Line vertical="true" line_color="gray" line_width="1" width="1"/>  <!-- 垂直线 -->
+```
+
+**日期选择 DateTime:**
+```xml
+<DateTime name="dt_start" width="160" height="30"
+          format="%Y-%m-%d" edit_format="date_calendar"/>
+```
+
+**超级链接 HyperLink:**
+```xml
+<HyperLink text="访问官网" url="https://example.com"
+           normal_text_color="blue" cursor_type="hand"/>
+```
+
+**IP地址 IPAddress:**
+```xml
+<IPAddress name="ip_server" width="200" height="30" ip="192.168.1.1"/>
+```
+
+**TabCtrl + TabBox 页签:**
+```xml
+<VBox>
+    <TabCtrl name="tab_ctrl" height="32">
+        <TabCtrlItem text="页签1" selected="true"/>
+        <TabCtrlItem text="页签2"/>
+    </TabCtrl>
+    <TabBox name="tab_box">
+        <VBox><!-- 页签1内容 --></VBox>
+        <VBox visible="false"><!-- 页签2内容 --></VBox>
+    </TabBox>
+</VBox>
+```
+
+### 3. C++ 事件绑定代码
+
+在窗口的 `OnInitWindow()` 中添加:
+
+```cpp
+// 按钮点击
+if (auto* btn = dynamic_cast<ui::Button*>(FindControl(_T("btn_submit")))) {
+    btn->AttachClick([this](const ui::EventArgs&) {
+        // 处理点击
+        return true;
+    });
+}
+
+// 复选框
+if (auto* chk = dynamic_cast<ui::CheckBox*>(FindControl(_T("chk_agree")))) {
+    chk->AttachSelect([this](const ui::EventArgs&) { /* 选中 */ return true; });
+    chk->AttachUnSelect([this](const ui::EventArgs&) { /* 取消 */ return true; });
+}
+
+// 输入框文本变化
+if (auto* edit = dynamic_cast<ui::RichEdit*>(FindControl(_T("edit_input")))) {
+    edit->AttachTextChange([this](const ui::EventArgs&) {
+        // 文本变化
+        return true;
+    });
+}
+
+// 下拉框选择变化
+if (auto* combo = dynamic_cast<ui::Combo*>(FindControl(_T("combo_type")))) {
+    combo->AttachSelect([this](const ui::EventArgs& args) {
+        size_t selIndex = args.wParam;
+        return true;
+    });
+}
+
+// 列表选择
+if (auto* list = dynamic_cast<ui::ListBox*>(FindControl(_T("list_items")))) {
+    list->AttachSelect([this](const ui::EventArgs& args) {
+        size_t newSel = args.wParam;
+        return true;
+    });
+}
+```
+
+### 4. 动态添加数据
+
+```cpp
+// Combo 添加选项
+if (auto* combo = dynamic_cast<ui::Combo*>(FindControl(_T("combo_type")))) {
+    auto* treeView = combo->GetTreeView();
+    auto* root = treeView->GetRootNode();
+    for (int i = 0; i < 5; i++) {
+        auto* node = new ui::TreeNode(this);
+        node->SetClass(_T("tree_node"));
+        node->SetText(ui::StringUtil::Printf(_T("选项 %d"), i));
+        root->AddChildNode(node);
+    }
+    combo->SetCurSel(0);
+}
+
+// ListBox 添加项
+if (auto* list = dynamic_cast<ui::ListBox*>(FindControl(_T("list_items")))) {
+    for (int i = 0; i < 20; i++) {
+        auto* item = new ui::ListBoxItem(this);
+        item->SetClass(_T("listitem"));
+        item->SetText(ui::StringUtil::Printf(_T("列表项 %d"), i));
+        item->SetFixedHeight(ui::UiFixedInt(28), true, true);
+        list->AddItem(item);
+    }
+}
+```

--- a/.claude/skills/nim-duilib-create-window.md
+++ b/.claude/skills/nim-duilib-create-window.md
@@ -1,0 +1,121 @@
+---
+name: nim-create-window
+description: 创建 nim_duilib 新窗口（生成 C++ 窗口类 + XML 布局文件 + 更新主线程）
+trigger: 当用户要求创建新窗口、新窗体、新对话框、新界面时触发
+---
+
+# nim_duilib 创建新窗口
+
+## 执行步骤
+
+### 1. 确认参数
+向用户确认以下信息（如果未提供）:
+- **窗口名称**: C++ 类名（如 `SettingsForm`）
+- **皮肤目录名**: XML文件所在目录名（如 `settings`）
+- **窗口标题**: 窗口显示的标题文字
+- **窗口尺寸**: 默认 "800,600"
+- **是否需要标题栏**: 默认 Yes（带最小化/最大化/关闭按钮）
+
+### 2. 生成 C++ 头文件
+在 `examples/<project>/` 或用户指定位置创建 `<FormName>.h`:
+
+```cpp
+#ifndef EXAMPLES_<FORM_NAME_UPPER>_H_
+#define EXAMPLES_<FORM_NAME_UPPER>_H_
+
+#include "duilib/duilib.h"
+
+class <FormName> : public ui::WindowImplBase
+{
+    typedef ui::WindowImplBase BaseClass;
+public:
+    <FormName>();
+    virtual ~<FormName>() override;
+
+    virtual DString GetSkinFolder() override;
+    virtual DString GetSkinFile() override;
+    virtual void OnInitWindow() override;
+};
+
+#endif // EXAMPLES_<FORM_NAME_UPPER>_H_
+```
+
+### 3. 生成 C++ 实现文件
+创建 `<FormName>.cpp`:
+
+```cpp
+#include "<FormName>.h"
+
+<FormName>::<FormName>() {}
+<FormName>::~<FormName>() {}
+
+DString <FormName>::GetSkinFolder()
+{
+    return _T("<skin_folder>");
+}
+
+DString <FormName>::GetSkinFile()
+{
+    return _T("<skin_file>.xml");
+}
+
+void <FormName>::OnInitWindow()
+{
+    BaseClass::OnInitWindow();
+    // TODO: 初始化控件和绑定事件
+}
+```
+
+### 4. 生成 XML 布局文件
+在 `bin/resources/themes/default/<skin_folder>/` 创建 `<skin_file>.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Window size="<width>,<height>" min_size="240,100"
+        caption="0,0,0,36" use_system_caption="false"
+        snap_layout_menu="true" sys_menu="true" sys_menu_rect="0,0,36,36"
+        shadow_type="default" shadow_attached="true"
+        layered_window="true" alpha="255" size_box="4,4,4,4"
+        icon="../public/caption/logo.ico">
+    <VBox bkcolor="bk_wnd_darkcolor">
+        <!-- 标题栏 -->
+        <HBox name="window_caption_bar" width="stretch" height="36" bkcolor="bk_wnd_lightcolor">
+            <Label text="<窗口标题>" margin="12,0,0,0" valign="center" normal_text_color="white"/>
+            <Control />
+            <Button class="btn_wnd_min_11" height="32" width="40" name="minbtn" margin="0,2,0,2"/>
+            <Box height="stretch" width="40" margin="0,2,0,2">
+                <Button class="btn_wnd_max_11" height="32" width="stretch" name="maxbtn"/>
+                <Button class="btn_wnd_restore_11" height="32" width="stretch" name="restorebtn" visible="false"/>
+            </Box>
+            <Button class="btn_wnd_close_11" height="stretch" width="40" name="closebtn" margin="0,0,0,2"/>
+        </HBox>
+        <!-- 内容区域 -->
+        <Box padding="12,12,12,12">
+            <VBox>
+                <!-- TODO: 在这里添加内容控件 -->
+                <Label text="<窗口标题>" text_align="hcenter,vcenter" height="100%" width="100%"/>
+            </VBox>
+        </Box>
+    </VBox>
+</Window>
+```
+
+### 5. 创建窗口的代码
+在需要打开此窗口的地方添加:
+
+```cpp
+#include "<FormName>.h"
+
+// 创建并显示窗口
+<FormName>* window = new <FormName>();
+window->CreateWnd(nullptr, ui::WindowCreateParam(_T("<窗口标题>"), true));
+window->ShowWindow(ui::kSW_SHOW_NORMAL);
+// 如果是主窗口，添加:
+// window->PostQuitMsgWhenClosed(true);
+```
+
+### 6. 检查清单
+- [ ] .h 和 .cpp 文件已添加到 VS 工程或 CMakeLists.txt
+- [ ] XML 文件编码为 UTF-8
+- [ ] XML 文件路径与 GetSkinFolder()/GetSkinFile() 返回值一致
+- [ ] 如果是示例工程，需要在 vcxproj 中添加引用

--- a/.claude/skills/nim-duilib-event-handler.md
+++ b/.claude/skills/nim-duilib-event-handler.md
@@ -1,0 +1,150 @@
+---
+name: nim-event-handler
+description: 为 nim_duilib 控件添加事件处理（支持 XML 内联事件和 C++ 事件绑定）
+trigger: 当用户需要处理控件事件、响应用户操作、绑定回调时触发
+---
+
+# nim_duilib 事件处理
+
+## 方式一: XML 内联事件（无需 C++ 代码）
+
+### 语法
+```xml
+<控件 name="source">
+    <Event type="事件类型" receiver="目标控件名" apply_attribute="属性名='属性值'"/>
+</控件>
+```
+
+### receiver 写法
+| 格式 | 含义 |
+|------|------|
+| `receiver="target_name"` | 按名称在窗口中查找控件 |
+| `receiver="./target_name"` | 在当前容器内查找 |
+| `receiver=""` | 控件自身 |
+| `receiver="#window#"` | 窗口对象 |
+| `receiver="name1 name2"` | 多个控件(空格分隔) |
+
+### 常见示例
+
+**点击按钮显示/隐藏面板:**
+```xml
+<Button name="btn_toggle" text="切换">
+    <Event type="click" receiver="panel" apply_attribute="visible='true'"/>
+</Button>
+```
+
+**单选切换内容:**
+```xml
+<Option group="tabs" text="页签1" selected="true">
+    <Event type="select" receiver="page1" apply_attribute="visible='true'"/>
+    <Event type="select" receiver="page2" apply_attribute="visible='false'"/>
+</Option>
+<Option group="tabs" text="页签2">
+    <Event type="select" receiver="page1" apply_attribute="visible='false'"/>
+    <Event type="select" receiver="page2" apply_attribute="visible='true'"/>
+</Option>
+```
+
+**鼠标悬浮切换样式:**
+```xml
+<Control name="card" bkcolor="white">
+    <Event type="mouse_enter" receiver="" apply_attribute="bkcolor='AliceBlue'"/>
+    <Event type="mouse_leave" receiver="" apply_attribute="bkcolor='white'"/>
+</Control>
+```
+
+**鼠标悬浮播放动画:**
+```xml
+<Control bkimage="file='fan.gif' auto_play='false' play_count='-1'">
+    <Event type="mouse_enter" receiver="" apply_attribute="start_image_animation={}"/>
+    <Event type="mouse_leave" receiver="" apply_attribute="stop_image_animation={}"/>
+</Control>
+```
+
+**修改窗口阴影类型:**
+```xml
+<Option group="shadow" text="大阴影">
+    <Event type="select" receiver="#window#" apply_attribute="shadow_type={big}"/>
+</Option>
+```
+
+**修改容器布局属性:**
+```xml
+<Option group="align" text="居中对齐">
+    <Event type="select" receiver="container" apply_attribute="child_halign='center'"/>
+</Option>
+```
+
+## 方式二: C++ 事件绑定
+
+### 常用 Attach 方法
+```cpp
+// 在 OnInitWindow() 中绑定
+
+// 点击
+control->AttachClick([this](const ui::EventArgs& args) -> bool {
+    return true;
+});
+
+// 选中/取消选中 (CheckBox/Option/ListBox)
+control->AttachSelect([](const ui::EventArgs&) { return true; });
+control->AttachUnSelect([](const ui::EventArgs&) { return true; });
+
+// 文本变化 (RichEdit)
+edit->AttachTextChange([](const ui::EventArgs&) { return true; });
+
+// 回车键 (RichEdit)
+edit->AttachReturn([](const ui::EventArgs&) { return true; });
+
+// Tab选择 (TabCtrl)
+tabCtrl->AttachTabSelect([](const ui::EventArgs& args) {
+    size_t newIndex = args.wParam;
+    size_t oldIndex = args.lParam;
+    return true;
+});
+
+// 值变化 (Progress/Slider)
+slider->AttachEvent(ui::kEventValueChange, [](const ui::EventArgs&) { return true; });
+
+// 通用事件绑定
+control->AttachEvent(ui::kEventMouseEnter, handler);
+control->AttachEvent(ui::kEventMouseLeave, handler);
+control->AttachEvent(ui::kEventKeyDown, handler);
+control->AttachEvent(ui::kEventSetFocus, handler);
+control->AttachEvent(ui::kEventKillFocus, handler);
+control->AttachEvent(ui::kEventWindowClose, handler);
+```
+
+### EventArgs 参数
+```cpp
+struct EventArgs {
+    EventType eventType;     // 事件类型
+    size_t wParam;           // 参数1
+    size_t lParam;           // 参数2
+    UiPoint ptMouse;         // 鼠标位置
+    uint16_t vkCode;         // 按键码
+    uint16_t modifierKey;    // 修饰键
+    int64_t eventData;       // 额外数据
+    Control* pSender;        // 发送控件
+};
+```
+
+### 完整事件类型列表
+键鼠: `kEventKeyDown`, `kEventKeyUp`, `kEventChar`, `kEventMouseEnter`, `kEventMouseLeave`, `kEventMouseMove`, `kEventMouseButtonDown`, `kEventMouseButtonUp`, `kEventMouseDoubleClick`, `kEventMouseRButtonDown`, `kEventMouseRButtonUp`, `kEventMouseWheel`, `kEventContextMenu`
+
+操作: `kEventClick`, `kEventRClick`, `kEventSelect`, `kEventUnSelect`, `kEventChecked`, `kEventUnCheck`, `kEventTabSelect`, `kEventExpand`, `kEventCollapse`
+
+编辑: `kEventTextChange`, `kEventSelChange`, `kEventReturn`, `kEventTab`, `kEventZoom`
+
+状态: `kEventSetFocus`, `kEventKillFocus`, `kEventStateChange`, `kEventVisibleChange`, `kEventResize`
+
+窗口: `kEventWindowClose`, `kEventWindowSize`, `kEventWindowMove`, `kEventWindowKillFocus`
+
+拖放: `kEventDropEnter`, `kEventDropOver`, `kEventDropLeave`, `kEventDropData`
+
+动画: `kEventImageAnimationStart`, `kEventImageAnimationStop`
+
+### 注意事项
+- 事件回调返回 `true` 表示已处理该事件
+- 使用 `UiBind` 绑定成员函数确保弱引用安全
+- lambda 中捕获 `this` 时用 `ui::UiBind(this, lambda)` 包装，防止控件销毁后回调崩溃

--- a/.claude/skills/nim-duilib-resource-pack.md
+++ b/.claude/skills/nim-duilib-resource-pack.md
@@ -1,0 +1,191 @@
+---
+name: nim-duilib-resource-pack
+description: nim_duilib 资源打包与部署（ZIP打包、嵌入EXE、单文件发布），配置资源加载方式
+---
+
+# nim_duilib 资源打包与部署
+
+## 三种资源加载模式
+
+### 模式 1：本地文件夹（开发时推荐）
+```cpp
+ui::FilePath resourcePath = ui::FilePathUtil::GetCurrentModuleDirectory();
+resourcePath += _T("resources\\");
+ui::GlobalManager::Instance().Startup(ui::LocalFilesResParam(resourcePath));
+```
+目录结构：
+```
+MyApp.exe
+resources/
+├── themes/default/
+│   ├── global.xml
+│   ├── public/...
+│   └── my_app/...
+├── fonts/...
+└── lang/...
+```
+
+### 模式 2：ZIP 压缩包（发布时推荐）
+```cpp
+ui::ZipFileResParam resParam;
+resParam.resourcePath = _T("resources\\");     // ZIP 内的相对路径
+resParam.zipFilePath = ui::FilePathUtil::GetCurrentModuleDirectory();
+resParam.zipFilePath += _T("resources.zip");   // ZIP 文件路径
+resParam.zipPassword = _T("");                 // 可选密码
+ui::GlobalManager::Instance().Startup(resParam);
+```
+发布文件：
+```
+MyApp.exe
+resources.zip        # 包含 resources/ 目录结构
+```
+
+### 模式 3：嵌入 EXE 资源（单文件发布，仅 Windows）
+```cpp
+#include "resource.h"
+
+ui::ResZipFileResParam resParam;
+resParam.resourcePath = _T("resources\\");
+resParam.hResModule = nullptr;                        // nullptr = 当前EXE
+resParam.resourceName = MAKEINTRESOURCE(IDR_THEME);   // 资源ID
+resParam.resourceType = _T("THEME");                  // 资源类型名
+resParam.zipPassword = _T("");
+ui::GlobalManager::Instance().Startup(resParam);
+```
+
+## 实现单 EXE 发布（模式 3 详细步骤）
+
+### 步骤 1：创建 resource.h
+```cpp
+// resource.h
+#ifndef RESOURCE_H_
+#define RESOURCE_H_
+
+#define IDR_THEME  101
+
+#endif // RESOURCE_H_
+```
+
+### 步骤 2：创建 .rc 资源文件
+```rc
+// MyApp.rc
+#include "resource.h"
+IDR_THEME  THEME  "..\\..\\bin\\resources.zip"
+```
+**注意**：路径是相对于 .rc 文件的位置。
+
+### 步骤 3：制作 resources.zip
+使用 7-Zip 打包（推荐参数，确保 UTF-8 文件名）：
+```bash
+cd bin
+7z a -tzip -mcu=on resources.zip resources/
+```
+
+**ZIP 要求：**
+- 压缩算法：仅支持 Deflate（不支持 Deflate64）
+- 文件名编码：UTF-8（7-Zip 用 `-mcu=on` 参数）
+- 密码加密：仅支持 ZipCrypto（ZIP 传统加密）
+
+### 步骤 4：在 MainThread 中切换加载模式
+```cpp
+void MainThread::OnInit()
+{
+#ifdef NDEBUG
+    // Release：使用嵌入 EXE 的 ZIP 资源
+    ui::ResZipFileResParam resParam;
+    resParam.resourcePath = _T("resources\\");
+    resParam.hResModule = nullptr;
+    resParam.resourceName = MAKEINTRESOURCE(IDR_THEME);
+    resParam.resourceType = _T("THEME");
+    resParam.zipPassword = _T("");
+    ui::GlobalManager::Instance().Startup(resParam);
+#else
+    // Debug：使用本地文件夹（方便修改和调试）
+    ui::FilePath resourcePath = ui::FilePathUtil::GetCurrentModuleDirectory();
+    resourcePath += _T("resources\\");
+    ui::GlobalManager::Instance().Startup(ui::LocalFilesResParam(resourcePath));
+#endif
+
+    // 创建窗口...
+}
+```
+
+### 步骤 5：添加 .rc 到工程
+- Visual Studio：右键项目 → 添加 → 现有项 → 选择 .rc 文件
+- CMakeLists.txt：
+```cmake
+# Windows 平台添加资源文件
+if(WIN32)
+    target_sources(MyApp PRIVATE MyApp.rc)
+endif()
+```
+
+## 打包清单：应该包含什么
+
+### 必须打包的资源
+```
+resources/
+├── themes/default/
+│   ├── global.xml                  # 必须
+│   ├── public/                     # 必须（全部 133 个文件）
+│   │   ├── button/                 # 窗口按钮 SVG
+│   │   ├── caption/                # 标题栏图标
+│   │   ├── checkbox/               # 复选框图标
+│   │   ├── combo/                  # 下拉框图标
+│   │   ├── option/                 # 单选按钮图标
+│   │   ├── scrollbar01/            # 滚动条资源
+│   │   ├── scrollbar02/            # 滚动条资源
+│   │   ├── shadow/                 # 窗口阴影
+│   │   ├── slider/                 # 滑块资源
+│   │   ├── tooltip/                # 提示框
+│   │   ├── tree/                   # 树控件图标
+│   │   ├── menu/                   # 菜单资源
+│   │   ├── progress/               # 进度条
+│   │   ├── animation/              # 加载动画 JSON
+│   │   └── ...
+│   └── my_app/                     # 你的应用 XML 和图片
+│       ├── main_form.xml
+│       └── ...
+├── fonts/                          # 可选：自定义字体
+└── lang/                           # 可选：多语言文件
+```
+
+### 严禁打包的内容
+| 不要打包 | 原因 |
+|---------|------|
+| themes/default/basic/ | 示例程序目录 |
+| themes/default/controls/ | 示例程序目录 |
+| themes/default/layout/ | 示例程序目录 |
+| themes/default/render/ | 示例程序目录 |
+| themes/default/chat/ | 示例程序目录 |
+| themes/default/cef/ | 示例程序目录 |
+| themes/default/cef_browser/ | 示例程序目录 |
+| themes/default/webview2/ | 示例程序目录 |
+| themes/default/webview2_browser/ | 示例程序目录 |
+| themes/default/list_box/ | 示例程序目录 |
+| themes/default/list_ctrl/ | 示例程序目录 |
+| themes/default/tree_view/ | 示例程序目录 |
+| themes/default/rich_edit/ | 示例程序目录 |
+| themes/default/color_picker/ | 示例程序目录 |
+| themes/default/dpi_aware/ | 示例程序目录 |
+| themes/default/move_control/ | 示例程序目录 |
+| themes/default/threads/ | 示例程序目录 |
+| themes/default/virtual_list_box/ | 示例程序目录 |
+| themes/default/child_window/ | 示例程序目录 |
+| themes/default/xml_preview/ | 示例程序目录 |
+| themes/default/MultiLang/ | 示例程序目录 |
+| bin/*.exe, bin/*.dll | 编译产物 |
+| bin/bin.zip | 编译产物压缩包 |
+
+**规则：只打包 global.xml + public/ + 你自己的应用目录 + fonts/(可选) + lang/(可选)**
+
+## 跨平台注意事项
+
+| 平台 | 支持的资源模式 |
+|------|--------------|
+| Windows | 本地文件 / ZIP文件 / 嵌入EXE(单文件) |
+| Linux | 本地文件 / ZIP文件 |
+| macOS | 本地文件 / ZIP文件 |
+| FreeBSD | 本地文件 / ZIP文件 |
+
+macOS/Linux 不支持嵌入EXE模式（无 Windows RC 资源机制），发布时使用 ZIP 文件模式。

--- a/.claude/skills/nim-duilib-theme.md
+++ b/.claude/skills/nim-duilib-theme.md
@@ -1,0 +1,212 @@
+---
+name: nim-duilib-theme
+description: nim_duilib 主题定制（颜色、字体、通用样式Class、图标），修改 global.xml 和创建自定义样式
+---
+
+# nim_duilib 主题与样式定制
+
+## 重要：资源文件规则
+
+### 新项目必须复制的资源（最小集）
+```
+bin/resources/
+├── themes/default/
+│   ├── global.xml                    # 必须：全局样式定义
+│   ├── public/                       # 必须：共享图片资源（133个文件）
+│   │   ├── button/                   # 窗口按钮图标(SVG)
+│   │   ├── caption/                  # 标题栏资源
+│   │   ├── checkbox/                 # 复选框图标
+│   │   ├── combo/                    # 下拉框图标
+│   │   ├── option/                   # 单选按钮图标
+│   │   ├── scrollbar01/              # 滚动条样式1
+│   │   ├── scrollbar02/              # 滚动条样式2
+│   │   ├── shadow/                   # 窗口阴影
+│   │   ├── slider/                   # 滑块资源
+│   │   ├── tooltip/                  # 工具提示
+│   │   ├── tree/                     # 树控件展开/折叠图标
+│   │   ├── menu/                     # 菜单资源
+│   │   ├── progress/                 # 进度条资源
+│   │   ├── animation/                # 加载动画(JSON)
+│   │   └── ...                       # 其他公共资源
+│   └── <your_app>/                   # 你的应用专属XML和图片
+│       └── your_form.xml
+├── fonts/                            # 可选：自定义字体文件
+│   └── RobotoMono-*.ttf
+└── lang/                             # 可选：多语言文件
+    ├── zh_CN.txt
+    └── en_US.txt
+```
+
+### 严禁复制的内容
+- **不要复制** `themes/default/basic/`、`controls/`、`layout/` 等示例目录
+- **不要复制** `themes/default/chat/`、`cef/`、`cef_browser/` 等 demo 目录
+- **不要复制** `bin/*.exe`、`bin/*.dll` 等二进制文件
+- **不要复制** `bin/bin.zip`
+- 只创建**你的应用自己的**皮肤目录（如 `themes/default/my_app/`）
+
+### 资源引用路径规则
+```xml
+<!-- 引用 public 目录下的共享资源（使用相对路径） -->
+normal_image="file='public/button/window-minimize.svg' width='24' height='24'"
+
+<!-- 引用同目录下的资源（不需要路径前缀） -->
+bkimage="my_background.png"
+
+<!-- 引用上级目录的 public 资源 -->
+bkimage="file='../public/shadow/shadow_big.svg' corner='64,64,68,70'"
+```
+
+## 预定义颜色速查
+
+### 窗口/背景色
+| 颜色名 | 值 | 用途 |
+|--------|------|------|
+| bk_wnd_darkcolor | #FFF0F2F5 | 窗口深色背景（浅灰） |
+| bk_wnd_lightcolor | #FFFFFFFF | 窗口浅色背景（白色） |
+| bk_main_wnd_title | #FF238EFA | 标题栏蓝色 |
+| bk_listitem_hovered | #FFF0F2F5 | 列表项悬浮 |
+| bk_listitem_selected | #FFE4E7EB | 列表项选中 |
+| bk_menuitem_hovered | #FFE1E6EB | 菜单项悬浮 |
+
+### 文字色
+| 颜色名 | 值 | 用途 |
+|--------|------|------|
+| default_font_color | #FF000000 | 默认黑色文字 |
+| disabled_font_color | #FFA1AEBC | 禁用灰色文字 |
+| default_link_font_color | #FF0000FF | 超链接蓝色 |
+| white | #FFFFFFFF | 白色 |
+| darkcolor | #FF333333 | 深灰色 |
+| lightcolor | #FF888888 | 浅灰色 |
+| blue | #FF006DD9 | 蓝色 |
+| red | #FFC63535 | 红色 |
+| green | #FF00BB96 | 绿色 |
+
+### 分割线色
+| 颜色名 | 值 | 用途 |
+|--------|------|------|
+| splitline_level1 | #FFD2D4D6 | 深色分割线 |
+| splitline_level2 | #FFEBEDF0 | 浅色分割线 |
+
+### 自定义颜色
+在 global.xml 中添加：
+```xml
+<TextColor name="my_brand_color" value="#FF1890FF"/>
+```
+颜色格式：`#AARRGGBB`（ARGB）或 `#RRGGBB`（RGB）或预定义名（Blue/Red/White...）
+
+## 预定义字体ID速查
+
+| 字体ID | 大小 | 样式 |
+|--------|------|------|
+| system_12 ~ system_22 | 12-22 | 常规 |
+| system_bold_12 ~ system_bold_22 | 12-22 | 粗体 |
+| system_underline_12 | 12 | 下划线 |
+| system_italic_12 | 12 | 斜体 |
+| system_strikeout_12 | 12 | 删除线 |
+| arial_12 ~ arial_22 | 12-22 | Arial 常规 |
+| arial_bold_12 ~ arial_bold_22 | 12-22 | Arial 粗体 |
+
+默认字体（未指定font时使用）：system_14
+
+### 自定义字体
+```xml
+<!-- 定义新字体ID -->
+<Font id="my_title_font" name="Microsoft YaHei" size="24" bold="true"/>
+
+<!-- 使用自带字体文件（放在 resources/fonts/ 目录） -->
+<FontFile file="MyFont-Regular.ttf" desc="我的字体，常规"/>
+<Font id="my_font_16" name="MyFont" size="16"/>
+```
+
+## 预定义通用样式(Class)速查
+
+### 按钮样式
+| Class名 | 说明 |
+|---------|------|
+| btn_global_blue_80x30 | 蓝色按钮(图片) |
+| btn_global_white_80x30 | 白色按钮(图片) |
+| btn_global_red_80x30 | 红色按钮(图片) |
+| btn_global_gray_80x30 | 灰色按钮(图片) |
+| btn_global_color_blue | 蓝色按钮(纯色) |
+| btn_global_color_white | 白色按钮(纯色) |
+| btn_global_color_red | 红色按钮(纯色) |
+| btn_global_color_gray | 灰色按钮(纯色) |
+| btn_wnd_min_11 | 窗口最小化按钮 |
+| btn_wnd_max_11 | 窗口最大化按钮 |
+| btn_wnd_restore_11 | 窗口还原按钮 |
+| btn_wnd_close_11 | 窗口关闭按钮 |
+| btn_wnd_fullscreen_11 | 全屏按钮 |
+
+### 输入控件样式
+| Class名 | 说明 |
+|---------|------|
+| simple | 简单输入框（无边框） |
+| simple_border | 带边框输入框 |
+| simple_border_bottom | 底部边框输入框（聚焦高亮） |
+| combo | 下拉组合框 |
+| filter_combo | 可过滤下拉框 |
+| check_combo | 多选下拉框 |
+| ip_address | IP地址输入 |
+| hot_key | 热键输入 |
+
+### 选择控件样式
+| Class名 | 说明 |
+|---------|------|
+| checkbox_1 | 复选框样式1 |
+| checkbox_2 | 复选框样式2 |
+| checkbox_toggle_1 | 开关样式1 |
+| checkbox_toggle_2 | 开关样式2 |
+| option_1 | 单选按钮样式1 |
+| option_2 | 单选按钮样式2 |
+
+### 列表/树样式
+| Class名 | 说明 |
+|---------|------|
+| list | 列表容器 |
+| listitem | 列表项 |
+| tree_view | 树控件 |
+| tree_node | 树节点 |
+| tree_node_checkbox | 带复选框的树节点 |
+
+### 进度条/滑块样式
+| Class名 | 说明 |
+|---------|------|
+| progress_horizontal_blue | 水平蓝色进度条 |
+| progress_vertical_blue | 垂直蓝色进度条 |
+| slider_horizontal_green | 水平绿色滑块 |
+| slider_vertical_green | 垂直绿色滑块 |
+
+### 菜单样式
+| Class名 | 说明 |
+|---------|------|
+| menu | 菜单容器 |
+| menu_element | 菜单项 |
+| menu_text | 菜单文字 |
+| menu_split_line | 菜单分割线 |
+
+### 其他
+| Class名 | 说明 |
+|---------|------|
+| tab_ctrl / tab_ctrl_item | 标签页 |
+| vscrollbar / hscrollbar | 滚动条样式1（简洁） |
+| vscrollbar2 / hscrollbar2 | 滚动条样式2（带按钮） |
+| rich_text | 富文本 |
+| hyper_link | 超链接 |
+| splitline_hor_level1 | 水平分割线（深色） |
+| splitline_hor_level2 | 水平分割线（浅色） |
+| splitline_ver_level1 | 垂直分割线 |
+
+### 自定义通用样式
+```xml
+<!-- 在 global.xml 中定义 -->
+<Class name="my_card"
+       bkcolor="white" border_size="1" border_color="light_gray"
+       border_round="8,8" padding="12,12,12,12"
+       box_shadow="color='#20000000' offset='0,2' blurradius='8' spreadradius='0'"/>
+
+<!-- 在 XML 布局中使用（class 必须在最前面） -->
+<Box class="my_card" width="200" height="150">
+    <Label text="卡片内容"/>
+</Box>
+```
+**注意：class 属性必须写在所有属性最前面。** 后续属性可覆盖 class 中的同名属性。

--- a/.claude/skills/nim-duilib-xml-layout.md
+++ b/.claude/skills/nim-duilib-xml-layout.md
@@ -1,0 +1,120 @@
+---
+name: nim-xml-layout
+description: 为 nim_duilib 窗口设计和生成 XML 布局
+trigger: 当用户需要设计界面布局、创建XML界面、修改界面结构时触发
+---
+
+# nim_duilib XML 布局设计
+
+## 执行步骤
+
+### 1. 理解需求
+确认用户想要的界面布局:
+- 界面包含哪些区域（标题栏、侧边栏、内容区、底部栏等）
+- 每个区域包含哪些控件
+- 布局方式（垂直排列、水平排列、网格等）
+
+### 2. 选择合适的容器
+
+**布局选择指南:**
+| 需求 | 推荐容器 |
+|------|---------|
+| 从上到下排列 | VBox |
+| 从左到右排列 | HBox |
+| 自动换行的水平排列 | HFlowBox |
+| 等宽网格 | VTileBox / HTileBox |
+| 行列网格（支持合并） | GridBox |
+| 需要滚动 | VScrollBox / HScrollBox |
+| 可选择的列表 | VListBox / HListBox |
+| 大数据量列表 | VirtualVListBox |
+| 多页签切换 | TabBox |
+
+**尺寸设置指南:**
+| 需求 | width/height 值 |
+|------|----------------|
+| 固定尺寸 | 数值如 "200" |
+| 填充父容器 | "stretch"（默认值） |
+| 适应内容 | "auto" |
+| 父容器百分比 | "50%" |
+
+### 3. 常用布局模板
+
+**表单布局（标签+输入框）:**
+```xml
+<VBox padding="20,20,20,20" child_margin_y="10">
+    <HBox height="auto" child_margin_x="10">
+        <Label text="用户名：" width="80" height="30" text_align="right,vcenter"/>
+        <RichEdit name="edit_username" width="stretch" height="30"
+                  single_line="true" prompt_text="请输入用户名"
+                  border_size="1" border_color="gray" border_round="4,4"/>
+    </HBox>
+    <HBox height="auto" child_margin_x="10">
+        <Label text="密码：" width="80" height="30" text_align="right,vcenter"/>
+        <RichEdit name="edit_password" width="stretch" height="30"
+                  single_line="true" password="true" prompt_text="请输入密码"
+                  border_size="1" border_color="gray" border_round="4,4"/>
+    </HBox>
+    <HBox height="auto" halign="right" child_margin_x="10" margin="0,20,0,0">
+        <Button name="btn_cancel" text="取消" width="80" height="32" class="btn_global_white_80x30"/>
+        <Button name="btn_ok" text="确定" width="80" height="32" class="btn_global_blue_80x30"/>
+    </HBox>
+</VBox>
+```
+
+**左右分栏布局:**
+```xml
+<HBox>
+    <!-- 左侧面板 -->
+    <VBox width="200" bkcolor="bk_wnd_lightcolor">
+        <VListBox name="nav_list" width="stretch" height="stretch"/>
+    </VBox>
+    <!-- 分隔线 -->
+    <Line vertical="true" line_color="gray" line_width="1" width="1"/>
+    <!-- 右侧内容 -->
+    <VBox width="stretch" padding="12,12,12,12">
+        <Label text="内容区域" text_align="hcenter,vcenter"/>
+    </VBox>
+</HBox>
+```
+
+**工具栏+内容:**
+```xml
+<VBox>
+    <!-- 工具栏 -->
+    <HBox height="40" bkcolor="bk_wnd_lightcolor" padding="4,4,4,4" child_margin_x="4">
+        <Button name="btn_new" text="新建" width="auto" height="stretch"/>
+        <Button name="btn_open" text="打开" width="auto" height="stretch"/>
+        <Button name="btn_save" text="保存" width="auto" height="stretch"/>
+        <Line vertical="true" line_color="gray" width="1" margin="4,0,4,0"/>
+        <Control /><!-- 弹性空间 -->
+        <RichEdit name="search_edit" width="200" height="28" single_line="true"
+                  prompt_text="搜索..." valign="center" border_size="1" border_color="gray"/>
+    </HBox>
+    <!-- 内容 -->
+    <Box width="stretch" height="stretch">
+        <!-- 内容区域 -->
+    </Box>
+</VBox>
+```
+
+**卡片网格:**
+```xml
+<VTileScrollBox columns="3" item_size="200,150" child_margin="10"
+                padding="10,10,10,10" vscrollbar="true">
+    <Box bkcolor="white" border_size="1" border_color="gray" border_round="8,8">
+        <VBox padding="12,12,12,12">
+            <Label text="卡片1" font="system_bold_14"/>
+            <Label text="描述文本" normal_text_color="gray"/>
+        </VBox>
+    </Box>
+    <!-- 更多卡片... -->
+</VTileScrollBox>
+```
+
+### 4. 关键规则
+- XML 文件编码必须是 **UTF-8**
+- `class` 属性必须写在**所有属性最前面**
+- 属性值内嵌引号用**单引号 `'`** 或 **花括号 `{}`** 代替双引号
+- `<Control />` 作为弹性占位符，在 HBox/VBox 中占据剩余空间
+- 窗口标题栏按钮的 name 必须是: `minbtn`, `maxbtn`, `restorebtn`, `closebtn`, `fullscreenbtn`
+- 颜色值格式: "#AARRGGBB"(ARGB) 或颜色名

--- a/.claude/unregister.sh
+++ b/.claude/unregister.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# nim_duilib AI toolchain - global unregister script
+# Usage: bash .claude/unregister.sh
+
+set -e
+
+CLAUDE_HOME="${HOME}/.claude"
+GLOBAL_SKILLS_DIR="${CLAUDE_HOME}/skills"
+
+echo "=== nim_duilib AI toolchain unregister ==="
+
+# Remove /nim-init
+if [ -d "${GLOBAL_SKILLS_DIR}/nim-init" ]; then
+    rm -rf "${GLOBAL_SKILLS_DIR}/nim-init"
+    echo "  - removed /nim-init"
+fi
+
+# Remove all nim-duilib-* global skills
+for skill_dir in "${GLOBAL_SKILLS_DIR}"/nim-duilib-*; do
+    if [ -d "$skill_dir" ]; then
+        echo "  - removed /$(basename "$skill_dir")"
+        rm -rf "$skill_dir"
+    fi
+done
+
+echo ""
+echo "All nim_duilib global skills removed."
+echo ""
+echo "Note: per-project files (.claude/docs/, CLAUDE.md) are not removed."
+echo "Clean them manually if needed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# nim_duilib - 跨平台 C++ UI 库
+
+## 项目概述
+nim_duilib 是基于 Skia 渲染引擎的跨平台 C++ UI 框架，采用 XML 描述界面布局 + C++ 控制逻辑的开发模式。
+- **支持平台**: Windows (7/10/11+), Linux, macOS (12+), FreeBSD
+- **渲染引擎**: Skia (CPU/OpenGL)
+- **构建工具**: CMake + Visual Studio / GCC / Clang
+- **C++ 标准**: C++17+
+
+## 项目结构
+```
+nim_duilib/
+├── duilib/              # 核心库源码
+│   ├── Core/            # 窗口、控件基类、事件、管理器
+│   ├── Control/         # UI控件（Button, Label, RichEdit, TreeView...）
+│   ├── Box/             # 容器控件（VBox, HBox, ListBox, TabBox...）
+│   ├── Layout/          # 布局引擎（HLayout, VLayout, GridLayout...）
+│   ├── Animation/       # 动画系统
+│   ├── Image/           # 图片处理（PNG/SVG/GIF/WEBP/APNG/Lottie/PAG）
+│   ├── Render/          # 渲染接口
+│   ├── RenderSkia/      # Skia渲染实现
+│   ├── Utils/           # 工具类（WindowImplBase, FilePath...）
+│   ├── CEFControl/      # CEF浏览器集成
+│   └── WebView2/        # WebView2控件
+├── examples/            # 21个示例程序
+├── docs/                # 完整文档
+├── bin/resources/       # 主题资源（XML布局、图片、字体）
+├── build/               # 构建脚本和解决方案
+└── cmake/               # CMake配置
+```
+
+## 开发模式（XML + C++）
+
+### XML 布局文件
+- 位置: `bin/resources/themes/default/<skin_folder>/<skin_file>.xml`
+- 全局资源: `bin/resources/themes/default/global.xml`（字体、颜色、通用样式）
+- 编码: UTF-8
+
+### C++ 代码三件套
+每个窗口通常需要三个文件:
+1. **MainThread** - 继承 `ui::FrameworkThread`，负责初始化和创建窗口
+2. **MainForm.h/cpp** - 继承 `ui::WindowImplBase`，实现窗口逻辑
+3. **XML布局文件** - 描述界面结构和样式
+
+### 关键代码模式
+
+**初始化全局资源:**
+```cpp
+ui::FilePath resourcePath = ui::FilePathUtil::GetCurrentModuleDirectory();
+resourcePath += _T("resources\\");
+ui::GlobalManager::Instance().Startup(ui::LocalFilesResParam(resourcePath));
+```
+
+**创建窗口:**
+```cpp
+MainForm* window = new MainForm();
+window->CreateWnd(nullptr, ui::WindowCreateParam(_T("WindowTitle"), true));
+window->PostQuitMsgWhenClosed(true);
+window->ShowWindow(ui::kSW_SHOW_NORMAL);
+```
+
+**查找控件:**
+```cpp
+ui::Button* btn = dynamic_cast<ui::Button*>(FindControl(_T("btn_name")));
+```
+
+**事件绑定:**
+```cpp
+btn->AttachClick([this](const ui::EventArgs& args) {
+    // 处理点击事件
+    return true;
+});
+```
+
+## 文档参考
+- 完整文档: `docs/Summary.md`（文档索引）
+- 控件属性: `docs/Control.md`
+- 容器/布局: `docs/Box.md`
+- 全局资源: `docs/Global.md`
+- 窗口属性: `docs/Window.md`
+- 事件系统: `docs/Events.md`
+- XML事件: `docs/XmlEvents.md`
+- XML节点名: `docs/XmlNode.md`
+- LLM详细参考: `.claude/docs/nim-duilib-llm-reference.md`
+
+## 编码规范
+- 字符串使用 `DString` 类型，字面量用 `_T("...")` 宏包裹
+- 控件查找用 `FindControl(_T("name"))`，需 `dynamic_cast` 到具体类型
+- 事件回调返回 `true` 表示已处理
+- XML属性值中内嵌引号用单引号`'`或花括号`{}`代替双引号
+- 控件类支持模板变体: `Label`(Control基)、`LabelBox`(Box基)、`LabelHBox`(HBox基)、`LabelVBox`(VBox基)
+- 窗口析构由框架管理，使用 `new` 创建，不需要手动 `delete`
+
+## 构建
+- Windows: 打开 `build/examples.sln`，选择 Debug|x64 或 Release|x64
+- 跨平台: `build/build_duilib_all_in_one.sh` 或 `build/build_duilib_all_in_one.bat`
+- 依赖: 需要先编译 Skia（参考 `build/build.md`）

--- a/README.md
+++ b/README.md
@@ -557,6 +557,81 @@ chmod +x ./build/freebsd_build.sh
  - 跨平台（Windows/Linux/macOS/FreeBSD）窗口引擎（基于[SDL3.0](https://www.libsdl.org/)）的不断测试与完善（目前X11/XWayland桌面环境下较稳定，但纯Wayland桌面环境下问题较多）
  - 测试界面库，发现缺陷并修复，不断完善代码
 
+## AI 辅助开发（Claude Code 集成）
+
+nim_duilib 提供了 AI 友好的文档和技能（Skills），可配合 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 实现 AI 辅助界面开发。
+
+### 功能说明
+注册后，Claude Code 在**任何项目**中都可以使用以下 nim_duilib 专属技能：
+
+| 指令 / 技能 | 说明 |
+| :--- | :--- |
+| `/nim-init` | 为当前项目初始化 nim_duilib 开发环境（复制 LLM 参考文档、更新 CLAUDE.md） |
+| `/nim-duilib-create-window` | 创建新窗口（自动生成 C++ 类 + XML 布局文件） |
+| `/nim-duilib-xml-layout` | 设计 XML 界面布局（表单、分栏、工具栏、卡片网格等模板） |
+| `/nim-duilib-add-control` | 添加控件（15+ 种控件的 XML 片段和 C++ 事件绑定代码） |
+| `/nim-duilib-event-handler` | 事件处理（XML 内联事件和 C++ Attach 绑定） |
+| `/nim-duilib-theme` | 主题定制（预定义颜色、字体、100+ 通用样式 Class 速查） |
+| `/nim-duilib-resource-pack` | 资源打包与部署（ZIP 打包、嵌入 EXE 单文件发布） |
+
+### 快速开始
+
+**前提条件：** 已安装 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+
+**第一步：注册（只需执行一次）**
+
+在 nim_duilib 根目录下执行：
+```bash
+# Windows (CMD / PowerShell)
+.claude\register.bat
+
+# Linux / macOS
+bash .claude/register.sh
+```
+注册脚本会将所有技能安装到 `~/.claude/skills/`，全局生效。
+
+**第二步：在你的应用项目中使用**
+
+在任何需要使用 nim_duilib 的项目中打开 Claude Code，输入：
+```
+/nim-init
+```
+AI 会自动为该项目配置 LLM 参考文档和 CLAUDE.md。之后即可直接用自然语言指示 Claude 完成界面开发，例如：
+- "创建一个设置窗口，包含用户名输入框和保存按钮"
+- "设计一个左侧导航栏 + 右侧内容区的布局"
+- "给这个按钮添加点击事件"
+- "把资源打包成单个 EXE"
+
+### 更新技能
+当 nim_duilib 的 AI 技能文件（`.claude/skills/`）有更新时，重新执行注册脚本即可：
+```bash
+cd nim_duilib
+.claude\register.bat   # Windows
+# bash .claude/register.sh  # Linux / macOS
+```
+
+### 注销
+如需移除所有全局技能：
+```bash
+bash nim_duilib/.claude/unregister.sh
+```
+
+### 文件结构
+```
+nim_duilib/.claude/
+├── register.bat / register.ps1 / register.sh   # 全局注册脚本
+├── unregister.sh                                # 注销脚本
+├── docs/
+│   └── nim-duilib-llm-reference.md              # LLM 完整参考手册
+└── skills/                                      # AI 技能定义
+    ├── nim-duilib-create-window.md
+    ├── nim-duilib-xml-layout.md
+    ├── nim-duilib-add-control.md
+    ├── nim-duilib-event-handler.md
+    ├── nim-duilib-theme.md
+    └── nim-duilib-resource-pack.md
+```
+
 ## 参考文档
 
  - [快速上手](docs/Getting-Started.md)


### PR DESCRIPTION
  ## Summary
  - 新增 `.claude/` AI 工具链（LLM 参考文档 + 6 个开发技能 + 注册/注销脚本）
  - 新增 `CLAUDE.md` 项目级 LLM 指令文件
  - 更新 `README.md` 添加 AI 辅助开发使用说明

  ## 功能
  - `/nim-init` 一键为应用项目配置 nim_duilib AI 开发环境
  - 6 个全局技能：创建窗口、XML 布局、添加控件、事件处理、主题定制、资源打包
  - 注册脚本支持 Windows (bat/ps1) 和 Linux/macOS (sh)