### PR TITLE
支持编译动态库的代码调整：使用VS2017时，默认禁用CEF模块，因其无法编译通过（#397）

### DIFF
--- a/msvc/PropertySheets/CEFSettings.props
+++ b/msvc/PropertySheets/CEFSettings.props
@@ -7,6 +7,8 @@
 
         <!-- 是否支持LibCefEnabled的宏定义： 0表示不支持；1 表示支持 -->
         <LibCefEnabled>1</LibCefEnabled>
+        <!-- VS2017的情况下： 默认不支持CEF，因为CEF模块编译不过 -->
+        <LibCefEnabled Condition="'$(VisualStudioVersion)' == '15.0'">0</LibCefEnabled>
         
         <!-- libCEF 版本控制的开关变量，有两种值：1表示使用libCEF 109 版本，0：表示用libCEF最新版本 -->
         <LibCefVersion109>0</LibCefVersion109>


### PR DESCRIPTION
支持编译动态库的代码调整：使用VS2017时，默认禁用CEF模块，因其无法编译通过（#397）
