### PR TITLE
Fix macOS fullscreen stretching by using exclusive fullscreen mode

### DIFF
--- a/build/macos_build.sh
+++ b/build/macos_build.sh
@@ -14,15 +14,14 @@ DUILIB_CC=clang
 DUILIB_CXX=clang++
 DUILIB_COMPILER_ID=llvm
 
-cmake_version=$(cmake --version | grep -oE '[0-9]+\.[0-9]+')
-required_version=3.24
-if [ $(echo "$cmake_version >= $required_version" | bc) -eq 1 ]; then
+# 首次构建或需要清理时: ./macos_build.sh --fresh
+if [[ "${1:-}" == "--fresh" ]]; then
     DUILIB_CMAKE_REFRESH=--fresh
 else
     DUILIB_CMAKE_REFRESH=
 fi
 
-DUILIB_CMAKE="cmake ${DUILIB_CMAKE_REFRESH} -DCMAKE_C_COMPILER=$DUILIB_CC -DCMAKE_CXX_COMPILER=$DUILIB_CXX"
+DUILIB_CMAKE="cmake ${DUILIB_CMAKE_REFRESH} -DCMAKE_C_COMPILER=$DUILIB_CC -DCMAKE_CXX_COMPILER=$DUILIB_CXX -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
 DUILIB_MAKE="cmake --build"
 DUILIB_MAKE_THREADS="-j 6"
 

--- a/duilib/Core/NativeWindow_SDL.cpp
+++ b/duilib/Core/NativeWindow_SDL.cpp
@@ -2346,6 +2346,18 @@ bool NativeWindow_SDL::EnterFullscreen()
     }
 #endif
 
+#if defined (__APPLE__)
+    //设置特定显示模式，使 SDL 使用独占全屏（绕过 Spaces），避免全屏拉伸动画
+    //同时 allow_spaces 保持默认 1，日常窗口正常有系统阴影
+    SDL_DisplayID displayID = SDL_GetDisplayForWindow(m_sdlWindow);
+    if (displayID != 0) {
+        const SDL_DisplayMode* desktopMode = SDL_GetDesktopDisplayMode(displayID);
+        if (desktopMode) {
+            SDL_SetWindowFullscreenMode(m_sdlWindow, desktopMode);
+        }
+    }
+#endif
+
     bool nRet = SDL_SetWindowFullscreen(m_sdlWindow, true);
     ASSERT_UNUSED_VARIABLE(nRet);
 
@@ -2369,6 +2381,13 @@ bool NativeWindow_SDL::ExitFullscreen()
 
     bool nRet = SDL_SetWindowFullscreen(m_sdlWindow, false);
     ASSERT_UNUSED_VARIABLE(nRet);
+
+#if defined (__APPLE__)
+    //清除独占全屏模式，恢复默认的桌面全屏行为（Spaces）
+    SDL_SetWindowFullscreenMode(m_sdlWindow, nullptr);
+    //退出全屏后需要恢复窗口阴影（SDL 在独占全屏退出时可能未正确恢复）
+    ModifyNsWindowShadowType(GetNSWindow(), m_systemShadowType);
+#endif
 
     if (m_lastWindowFlags & SDL_WINDOW_RESIZABLE) {
         //需要恢复可调整窗口大小的属性

--- a/duilib/Core/NativeWindow_SDL.cpp
+++ b/duilib/Core/NativeWindow_SDL.cpp
@@ -2387,6 +2387,8 @@ bool NativeWindow_SDL::ExitFullscreen()
     SDL_SetWindowFullscreenMode(m_sdlWindow, nullptr);
     //退出全屏后需要恢复窗口阴影（SDL 在独占全屏退出时可能未正确恢复）
     ModifyNsWindowShadowType(GetNSWindow(), m_systemShadowType);
+    //延迟再设置一次，确保 SDL 异步重置 style mask 后依然能恢复系统圆角
+    RestoreWindowShadowAfterFullscreen(GetNSWindow(), m_systemShadowType);
 #endif
 
     if (m_lastWindowFlags & SDL_WINDOW_RESIZABLE) {

--- a/duilib/Core/SDL_MacOS.h
+++ b/duilib/Core/SDL_MacOS.h
@@ -24,6 +24,12 @@ bool SetFocus_MacOS(void* pNSWindow);
 */
 bool ModifyNsWindowShadowType(void* pNSWindow, NativeWindowShadowType nativeShadowType);
 
+/** 全屏退出后延迟恢复窗口阴影（确保 SDL 完成全屏退出动作后再设置圆角）
+@param [in] pNSWindow 窗口指针
+@param [in] nativeShadowType 系统阴影类型
+*/
+void RestoreWindowShadowAfterFullscreen(void* pNSWindow, NativeWindowShadowType nativeShadowType);
+
 }
 
 #endif

--- a/duilib/Core/SDL_MacOS.mm
+++ b/duilib/Core/SDL_MacOS.mm
@@ -69,7 +69,25 @@ bool ModifyNsWindowShadowType(void* pNSWindow, NativeWindowShadowType nativeShad
         return true;
     }
 
-    // 4. 处理图层逻辑
+    // 4. 将 SDL 创建的 borderless 窗口转换为文档窗口：
+    //    替换 mask → 获得系统圆角和深度阴影
+    //    FullSizeContentView + titlebarAppearsTransparent → 隐藏标题栏
+    //    全屏退出后通过 toggle NSWindowStyleMaskTitled 强制 WindowServer 重新复合以恢复系统圆角
+    if (nativeShadowType != NativeWindowShadowType::kShadowSystemDisabled) {
+        window.titlebarAppearsTransparent = YES;
+        window.titleVisibility = NSWindowTitleHidden;
+        NSWindowStyleMask requiredMask = NSWindowStyleMaskTitled | NSWindowStyleMaskFullSizeContentView
+                                       | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+        if ((window.styleMask & requiredMask) != requiredMask) {
+            [window setStyleMask:requiredMask];
+
+            [[window standardWindowButton:NSWindowCloseButton] setHidden:YES];
+            [[window standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
+            [[window standardWindowButton:NSWindowZoomButton] setHidden:YES];
+        }
+    }
+
+    // 5. 处理图层逻辑
     switch (nativeShadowType) {
         case NativeWindowShadowType::kShadowSystemDisabled:
         {
@@ -84,43 +102,35 @@ bool ModifyNsWindowShadowType(void* pNSWindow, NativeWindowShadowType nativeShad
             }
             break;
         }
-            
+
         case NativeWindowShadowType::kShadowSystemDefault:
         case NativeWindowShadowType::kShadowSystemRound:
         {
             [window setHasShadow:YES];
-            
-            // 确保图层存在
-            contentView.wantsLayer = YES;
-            CALayer* layer = contentView.layer;
-            if (layer) {
-                layer.cornerRadius = 10.0; 
-                layer.masksToBounds = YES;
-            }
-            
+            // 不设置自定义 cornerRadius，由系统圆角统一处理窗口外观
             window.backgroundColor = [NSColor clearColor];
             break;
         }
-            
+
         case NativeWindowShadowType::kShadowSystemSmallRound:
         {
             [window setHasShadow:YES];
-            
+
             contentView.wantsLayer = YES;
             CALayer* layer = contentView.layer;
             if (layer) {
                 layer.cornerRadius = 5.0;
                 layer.masksToBounds = YES;
             }
-            
+
             window.backgroundColor = [NSColor clearColor];
             break;
         }
-            
+
         case NativeWindowShadowType::kShadowSystemDoNotRound:
         {
             [window setHasShadow:YES];
-            
+
             // 移除圆角
             if (contentView.wantsLayer) {
                 CALayer* layer = contentView.layer;
@@ -136,6 +146,17 @@ bool ModifyNsWindowShadowType(void* pNSWindow, NativeWindowShadowType nativeShad
     // 5. 强制刷新阴影
     [window invalidateShadow];    
     return true;
+}
+
+void RestoreWindowShadowAfterFullscreen(void* pNSWindow, NativeWindowShadowType nativeShadowType)
+{
+    if (!pNSWindow) {
+        return;
+    }
+    // 延迟到下一个 runloop 再设置，确保 SDL 退出全屏的动作完全结束
+    dispatch_async(dispatch_get_main_queue(), ^{
+        ModifyNsWindowShadowType(pNSWindow, nativeShadowType);
+    });
 }
 
 }


### PR DESCRIPTION
Fix macOS fullscreen stretching by using exclusive fullscreen mode #415 

全屏时设置特定显示模式，使 SDL 使用独占全屏（绕过 Spaces），避免全屏拉伸动画,同时保持日常窗口正常有系统阴影;

退出全屏时,清除独占全屏模式，恢复默认的桌面全屏行为（Spaces）,退出全屏后恢复窗口阴影.

这样简单修复可以全屏和退出全屏时,没有拉伸字体控件等渲染内容的问题,但是这样没有了全屏动画,不过使用起来暂时没什么影响.

