### PR TITLE
修复VS 2017下的编译错误：兼容：Win10 SDK 补全 Win11 DWM 相关定义。

### DIFF
--- a/duilib/Box/ScrollBox.cpp
+++ b/duilib/Box/ScrollBox.cpp
@@ -134,8 +134,10 @@ void ScrollBox::DoSetPos(UiRect rc, bool bScrollProcess)
         return;
     }
     struct DepthGuard {
-        int32_t& m_depth;
+        DepthGuard(int32_t& depth) : m_depth(depth) {}
         ~DepthGuard() { --m_depth; }
+
+        int32_t& m_depth;
     } guard(s_recursionDepth);
 
     UiSize oldScrollOffset = GetScrollOffset();

--- a/duilib/Utils/ApiWrapper_Windows.cpp
+++ b/duilib/Utils/ApiWrapper_Windows.cpp
@@ -955,6 +955,30 @@ bool UiIsWindows7OrOlder()
     return ::IsWindows7OrGreater() && !::IsWindows8OrGreater();
 }
 
+// ===================== 兼容：Win10 SDK 补全 Win11 DWM 相关定义 =====================
+// 定义目标最低 SDK 版本：Windows 11 (21H2) -> 10.0.22000.0
+// NTDDI_WIN10_CO 对应 Windows 11 21H2 (Build 22000)
+#ifndef NTDDI_WIN10_CO
+    #define NTDDI_WIN10_CO 0x0A00000B
+#endif
+
+#if (WDK_NTDDI_VERSION < NTDDI_WIN10_CO)
+    // DWM 窗口圆角偏好枚举
+    typedef enum
+    {
+        DWMWCP_DEFAULT = 0,
+        DWMWCP_DONOTROUND = 1,
+        DWMWCP_ROUND = 2,
+        DWMWCP_ROUNDSMALL = 3
+    } DWM_WINDOW_CORNER_PREFERENCE;
+
+    // 窗口圆角偏好属性
+    #define DWMWA_WINDOW_CORNER_PREFERENCE          33
+    // 可视边框厚度属性
+    #define DWMWA_VISIBLE_FRAME_BORDER_THICKNESS    37
+#endif
+// ==================================================================================
+
 bool IsDwmCompositionEnabled()
 {
     HMODULE hDwm = DllManager::Instance().LoadDll(_T("dwmapi.dll"));

--- a/examples/ColorTheme/ColorTheme.vcxproj
+++ b/examples/ColorTheme/ColorTheme.vcxproj
@@ -31,26 +31,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
修复VS 2017下的编译错误：兼容：Win10 SDK 补全 Win11 DWM 相关定义。
