### PR TITLE
修复图片缩放传入参数错误导致有Alpha通道的图片失真的问题。

### DIFF
--- a/duilib/Control/ChildWindow.cpp
+++ b/duilib/Control/ChildWindow.cpp
@@ -176,14 +176,15 @@ void ChildWindow::RegisterWindowCallbacks(Window* pWindow)
     if ((pWindow == nullptr) || !pWindow->IsWindow()) {
         return;
     }
-    pWindow->AttachWindowMoveMsg([this, pWindow](const EventArgs&) {
-        if (GetWindow() == pWindow) {
+    std::weak_ptr<WeakFlag> windowFlag = this->GetWeakFlag();//避免this失效，导致回调函数中出粗
+    pWindow->AttachWindowMoveMsg([this, pWindow, windowFlag](const EventArgs&) {
+        if (!windowFlag.expired() && GetWindow() == pWindow) {
             AdjustChildWindowPos();
         }
         return true;
         }, m_callbackID);
-    pWindow->AttachWindowPosChangedMsg([this, pWindow](const EventArgs&) {
-        if (GetWindow() == pWindow) {
+    pWindow->AttachWindowPosChangedMsg([this, pWindow, windowFlag](const EventArgs&) {
+        if (!windowFlag.expired() && GetWindow() == pWindow) {
             AdjustChildWindowPos();
         }
         return true;

--- a/duilib/Image/ImageUtil.cpp
+++ b/duilib/Image/ImageUtil.cpp
@@ -170,7 +170,7 @@ bool ImageUtil::ResizeImageData(const uint8_t* pPixelBits, size_t nPixelBitsLen,
         int output_w = (int)nNewWidth;
         int output_h = (int)nNewHeight;
         int output_stride_in_bytes = 0;
-        stbir_pixel_layout num_channels = STBIR_RGBA;
+        stbir_pixel_layout num_channels = STBIR_RGBA_PM;
         unsigned char* result = stbir_resize_uint8_linear(input_pixels, input_w, input_h, input_stride_in_bytes,
                                                           output_pixels, output_w, output_h, output_stride_in_bytes,
                                                           num_channels);


### PR DESCRIPTION
修复图片缩放传入参数错误导致有Alpha通道的图片失真的问题。
